### PR TITLE
Presence First Pass

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,6 +18,11 @@ const files = fs
   .filter((dirent) => dirent.isFile())
   .map((dirent) => dirent.name);
 
+// Initialize the document using our data structure for representing files.
+//  * Keys are file ids, which are random numbers.
+//  * Values are objects with properties:
+//    * text - the text content of the file
+//    * name - the file name
 const initialDocument = {};
 files.forEach((file) => {
   const id = Math.floor(Math.random() * 10000000000);

--- a/cli.js
+++ b/cli.js
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { json1Presence } from './src/ot.js';
+import { randomId } from './src/randomId.js';
 
 const fullPath = process.cwd();
 
@@ -25,7 +26,7 @@ const files = fs
 //    * name - the file name
 const initialDocument = {};
 files.forEach((file) => {
-  const id = Math.floor(Math.random() * 10000000000);
+  const id = randomId();
   initialDocument[id] = {
     text: fs.readFileSync(file, 'utf-8'),
     name: file,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import ShareDBClient from 'sharedb-client-browser/dist/sharedb-client-umd.cjs';
 import { json1Presence } from './ot';
 import { CodeEditor } from './CodeEditor';
 import { diff } from './diff';
+import { randomId } from './randomId';
 import './style.css';
 
 // Register our custom JSON1 OT type that supports presence.
@@ -67,7 +68,7 @@ function App() {
 
       // Set up presence.
       // See https://github.com/share/sharedb/blob/master/examples/rich-text-presence/client.js#L53
-      const presence = doc.connection.getDocPresence(collection, id);
+      const presence = shareDBDoc.connection.getDocPresence(collection, id);
 
       // Subscribe to receive remote presence updates.
       presence.subscribe(function (error) {
@@ -75,8 +76,7 @@ function App() {
       });
 
       // Set up our local presence for broadcasting this client's presence.
-      const localPresence = presence.create(presenceId);
-      setLocalPresence(localPresence);
+      setLocalPresence(presence.create(randomId()));
     });
 
     // TODO unsubscribe from presence
@@ -204,6 +204,7 @@ function App() {
         <CodeEditor
           className="editor"
           shareDBDoc={shareDBDoc}
+          localPresence={localPresence}
           activeFileId={activeFileId}
         />
       ) : null}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,10 +20,14 @@ function App() {
   // The ShareDB document.
   const [shareDBDoc, setShareDBDoc] = useState(null);
 
-  // The ShareDB presence, for broadcasting our cursor position
+  // Local ShareDB presence, for broadcasting our cursor position
   // so other clients can see it.
   // See https://share.github.io/sharedb/api/local-presence
   const [localPresence, setLocalPresence] = useState(null);
+
+  // The document-level presence object, which emits
+  // changes in remote presence.
+  const [docPresence, setDocPresence] = useState(null);
 
   // The `doc.data` part of the ShareDB document,
   // updated on each change to decouple rendering from ShareDB.
@@ -68,15 +72,18 @@ function App() {
 
       // Set up presence.
       // See https://github.com/share/sharedb/blob/master/examples/rich-text-presence/client.js#L53
-      const presence = shareDBDoc.connection.getDocPresence(collection, id);
+      const docPresence = shareDBDoc.connection.getDocPresence(collection, id);
 
       // Subscribe to receive remote presence updates.
-      presence.subscribe(function (error) {
+      docPresence.subscribe(function (error) {
         if (error) throw error;
       });
 
       // Set up our local presence for broadcasting this client's presence.
-      setLocalPresence(presence.create(randomId()));
+      setLocalPresence(docPresence.create(randomId()));
+
+      // Store docPresence so child components can listen for changes.
+      setDocPresence(docPresence);
     });
 
     // TODO unsubscribe from presence
@@ -205,6 +212,7 @@ function App() {
           className="editor"
           shareDBDoc={shareDBDoc}
           localPresence={localPresence}
+          docPresence={docPresence}
           activeFileId={activeFileId}
         />
       ) : null}

--- a/src/CodeEditor.jsx
+++ b/src/CodeEditor.jsx
@@ -1,7 +1,12 @@
 import { useRef, useLayoutEffect } from 'react';
 import { getOrCreateEditor } from './getOrCreateEditor';
 
-export const CodeEditor = ({ activeFileId, shareDBDoc, localPresence }) => {
+export const CodeEditor = ({
+  activeFileId,
+  shareDBDoc,
+  localPresence,
+  docPresence,
+}) => {
   const ref = useRef();
 
   // useEffect was buggy in that sometimes ref.current was undefined.
@@ -11,6 +16,7 @@ export const CodeEditor = ({ activeFileId, shareDBDoc, localPresence }) => {
       fileId: activeFileId,
       shareDBDoc,
       localPresence,
+      docPresence,
     });
     ref.current.appendChild(editor.dom);
 

--- a/src/CodeEditor.jsx
+++ b/src/CodeEditor.jsx
@@ -1,13 +1,19 @@
 import { useRef, useLayoutEffect } from 'react';
 import { getOrCreateEditor } from './getOrCreateEditor';
 
-export const CodeEditor = ({ activeFileId, shareDBDoc }) => {
+export const CodeEditor = ({ activeFileId, shareDBDoc, localPresence }) => {
+  console.log('shareDBDoc');
+  console.log(shareDBDoc);
   const ref = useRef();
 
   // useEffect was buggy in that sometimes ref.current was undefined.
   // useLayoutEffect seems to solve that issue.
   useLayoutEffect(() => {
-    const editor = getOrCreateEditor(activeFileId, shareDBDoc);
+    const editor = getOrCreateEditor({
+      fileId: activeFileId,
+      shareDBDoc,
+      localPresence,
+    });
     ref.current.appendChild(editor.dom);
 
     return () => {

--- a/src/CodeEditor.jsx
+++ b/src/CodeEditor.jsx
@@ -2,8 +2,6 @@ import { useRef, useLayoutEffect } from 'react';
 import { getOrCreateEditor } from './getOrCreateEditor';
 
 export const CodeEditor = ({ activeFileId, shareDBDoc, localPresence }) => {
-  console.log('shareDBDoc');
-  console.log(shareDBDoc);
   const ref = useRef();
 
   // useEffect was buggy in that sometimes ref.current was undefined.

--- a/src/getOrCreateEditor.js
+++ b/src/getOrCreateEditor.js
@@ -8,6 +8,7 @@ import { oneDark } from '@codemirror/theme-one-dark';
 import { json1Sync } from 'codemirror-ot';
 import { json1Presence, textUnicode } from './ot';
 import { json1PresenceBroadcast } from './json1PresenceBroadcast';
+import { json1PresenceDisplay } from './json1PresenceDisplay';
 
 // Singleton cache of CodeMirror instances
 // These are created, but never destroyed.
@@ -17,7 +18,12 @@ import { json1PresenceBroadcast } from './json1PresenceBroadcast';
 const editorCache = new Map();
 
 // Gets or creates a CodeMirror editor for the given file id.
-export const getOrCreateEditor = ({ fileId, shareDBDoc, localPresence }) => {
+export const getOrCreateEditor = ({
+  fileId,
+  shareDBDoc,
+  localPresence,
+  docPresence,
+}) => {
   const data = shareDBDoc.data;
 
   const fileExtension = data[fileId].name.split('.').pop();
@@ -36,11 +42,12 @@ export const getOrCreateEditor = ({ fileId, shareDBDoc, localPresence }) => {
       textUnicode,
     }),
 
-    json1PresenceBroadcast({ json1: json1Presence, path, localPresence }),
+    // Deals with broadcasting changes in cursor location and selection.
+    json1PresenceBroadcast({ path, localPresence }),
 
-    // TODO develop another plugin that deals with presence
-    // See
-    //  * https://github.com/yjs/y-codemirror.next/blob/main/src/y-remote-selections.js
+    // Deals with receiving the broadcas from other clients and displaying them.
+    json1PresenceDisplay({ path, docPresence }),
+
     basicSetup,
     oneDark,
   ];

--- a/src/getOrCreateEditor.js
+++ b/src/getOrCreateEditor.js
@@ -51,10 +51,12 @@ export const getOrCreateEditor = ({ fileId, shareDBDoc, localPresence }) => {
         // Translate this into the form expected by json1Presence.
         const presence = { start: [...path, from], end: [...path, to] };
 
-        // TODO broadcast this!
-        console.log(presence);
+        // Broadcast presence to remote clients!
+        // See https://github.com/share/sharedb/blob/master/examples/rich-text-presence/client.js#L71
+        localPresence.submit(presence, (error) => {
+          if (error) throw error;
+        });
       }
-      console.log(viewUpdate);
     }),
 
     // TODO develop another plugin that deals with presence

--- a/src/json1PresenceBroadcast.js
+++ b/src/json1PresenceBroadcast.js
@@ -1,0 +1,26 @@
+import { EditorView } from 'codemirror';
+
+// Deals with broadcasting changes in cursor location and selection.
+export const json1PresenceBroadcast = ({ path, localPresence }) =>
+  // See https://discuss.codemirror.net/t/codemirror-6-proper-way-to-listen-for-changes/2395/10
+  EditorView.updateListener.of((viewUpdate) => {
+    // If this update modified the cursor / selection,
+    // we broadcast the selection update via ShareDB presence.
+    if (viewUpdate.selectionSet) {
+      // Isolate the single selection to use for presence.
+      // Unfortunately JSON1 with presence does not yet
+      // support multiple selections.
+      // See https://github.com/ottypes/json1/pull/25#issuecomment-1459616521
+      const selection = viewUpdate.state.selection.ranges[0];
+      const { from, to } = selection;
+
+      // Translate this into the form expected by json1Presence.
+      const presence = { start: [...path, from], end: [...path, to] };
+
+      // Broadcast presence to remote clients!
+      // See https://github.com/share/sharedb/blob/master/examples/rich-text-presence/client.js#L71
+      localPresence.submit(presence, (error) => {
+        if (error) throw error;
+      });
+    }
+  });

--- a/src/json1PresenceDisplay.js
+++ b/src/json1PresenceDisplay.js
@@ -46,10 +46,12 @@ export const json1PresenceDisplay = ({ path, docPresence }) => [
               const presence = this.presenceState[id];
               const { start, end } = presence;
               const from = start[start.length - 1];
-              const to = end[end.length - 1];
+              // TODO support selection ranges (first attempt introduced layout errors)
+              //const to = end[end.length - 1];
               return {
                 from,
-                to,
+                //to,
+                to: from, // Temporary meaure
                 value: Decoration.widget({
                   side: -1,
                   block: false,
@@ -100,6 +102,7 @@ class PresenceWidget extends WidgetType {
     const span = document.createElement('span');
     span.setAttribute('aria-hidden', 'true');
     span.className = 'cm-json1-presence';
+    span.appendChild(document.createElement('div'));
     return span;
   }
 
@@ -111,11 +114,14 @@ class PresenceWidget extends WidgetType {
 const presenceTheme = EditorView.baseTheme({
   '.cm-json1-presence': {
     position: 'relative',
-    borderLeft: '1px solid black',
-    borderRight: '1px solid black',
-    marginLeft: '-1px',
-    marginRight: '-1px',
-    boxSizing: 'border-box',
-    display: 'inline',
+  },
+  '.cm-json1-presence > div': {
+    position: 'absolute',
+    top: '0',
+    bottom: '0',
+    left: '0',
+    right: '0',
+    borderLeft: '1px solid yellow',
+    //borderRight: '1px solid black',
   },
 });

--- a/src/json1PresenceDisplay.js
+++ b/src/json1PresenceDisplay.js
@@ -21,6 +21,8 @@ export const json1PresenceDisplay = ({ path, docPresence }) => [
         this.decorations = RangeSet.of([]);
 
         this.presenceState = {};
+
+        // Receive remote presence changes.
         docPresence.on('receive', (id, presence) => {
           if (presence) {
             this.presenceState[id] = presence;
@@ -38,16 +40,21 @@ export const json1PresenceDisplay = ({ path, docPresence }) => [
         );
         if (isPresenceUpdate) {
           this.decorations = Decoration.set(
-            Object.keys(this.presenceState).map((id) => ({
-              from: 0,
-              to: 0,
-              value: Decoration.widget({
-                side: -1,
-                block: false,
-                widget: new PresenceWidget(id),
-              }),
-            })),
-            true
+            Object.keys(this.presenceState).map((id) => {
+              const presence = this.presenceState[id];
+              const { start, end } = presence;
+              const from = start[start.length - 1];
+              const to = end[end.length - 1];
+              return {
+                from,
+                to,
+                value: Decoration.widget({
+                  side: -1,
+                  block: false,
+                  widget: new PresenceWidget(id),
+                }),
+              };
+            })
           );
           console.log(this.decorations);
         }

--- a/src/json1PresenceDisplay.js
+++ b/src/json1PresenceDisplay.js
@@ -24,12 +24,14 @@ export const json1PresenceDisplay = ({ path, docPresence }) => [
 
         // Receive remote presence changes.
         docPresence.on('receive', (id, presence) => {
-          if (presence) {
-            this.presenceState[id] = presence;
-          } else {
-            delete this.presenceState[id];
+          if (pathMatches(path, presence)) {
+            if (presence) {
+              this.presenceState[id] = presence;
+            } else {
+              delete this.presenceState[id];
+            }
+            view.dispatch({ annotations: [presenceAnnotation.of(true)] });
           }
-          view.dispatch({ annotations: [presenceAnnotation.of(true)] });
         });
       }
 
@@ -54,9 +56,9 @@ export const json1PresenceDisplay = ({ path, docPresence }) => [
                   widget: new PresenceWidget(id),
                 }),
               };
-            })
+            }),
+            true
           );
-          console.log(this.decorations);
         }
       }
     },
@@ -68,6 +70,20 @@ export const json1PresenceDisplay = ({ path, docPresence }) => [
 ];
 
 const presenceAnnotation = Annotation.define();
+
+// Checks that the path of this file
+// matches the path of the presence.
+//  * If true is returned, the presence is in this file.
+//  * If false is returned, the presence is in another file.
+// Assumption: start and end path are the same except the cursor position.
+const pathMatches = (path, presence) => {
+  for (let i = 0; i < path.length; i++) {
+    if (path[i] !== presence.start[i]) {
+      return false;
+    }
+  }
+  return true;
+};
 
 // Displays a single remote presence cursor.
 class PresenceWidget extends WidgetType {

--- a/src/json1PresenceDisplay.js
+++ b/src/json1PresenceDisplay.js
@@ -1,4 +1,6 @@
-import { ViewPlugin } from '@codemirror/view';
+import { ViewPlugin, EditorView, WidgetType } from '@codemirror/view';
+import { Annotation, RangeSet } from '@codemirror/state';
+import { randomId } from './randomId';
 
 // Deals with receiving the broadcas from other clients and displaying them.
 //
@@ -6,19 +8,76 @@ import { ViewPlugin } from '@codemirror/view';
 //  * https://github.com/yjs/y-codemirror.next/blob/main/src/y-remote-selections.js
 //  * https://codemirror.net/examples/decoration/
 //  * https://github.com/share/sharedb/blob/master/examples/rich-text-presence/client.js
-export const json1PresenceDisplay = ({ path, docPresence }) =>
+export const json1PresenceDisplay = ({ path, docPresence }) => [
   ViewPlugin.fromClass(
     class {
       constructor(view) {
         //this.decorations = [];
         docPresence.on('receive', (id, presence) => {
-          console.log('received presence ' + JSON.stringify(presence));
+          //console.log('received presence');
+          //console.log(JSON.stringify({ id, presence }));
+          view.dispatch({ annotations: [presenceAnnotation.of(true)] });
         });
+
+        this.decorations = RangeSet.of([]);
       }
 
-      //update(update) {}
+      update(update) {
+        // Figure out if this update is from a change in presence.
+        //let isPresenceUpdate = false;
+        //for (const tr of update.transactions) {
+        //  if (tr.annotation(presenceAnnotation)) {
+        //    isPresenceUpdate = true;
+        //    break;
+        //  }
+        //}
+        const isPresenceUpdate = update.transactions.some((tr) =>
+          tr.annotation(presenceAnnotation)
+        );
+        console.log(isPresenceUpdate);
+      }
     },
     {
-      //decorations: (v) => v.decorations,
+      decorations: (v) => v.decorations,
     }
-  );
+  ),
+  presenceTheme,
+];
+
+const presenceAnnotation = Annotation.define();
+
+// Displays a single remote presence cursor.
+class PresenceWidget extends WidgetType {
+  constructor() {
+    super();
+    // TODO use the actual user presence ids
+    this.id = randomId();
+  }
+
+  eq(other) {
+    return other.id === this.id;
+  }
+
+  toDOM() {
+    const span = document.createElement('span');
+    span.setAttribute('aria-hidden', 'true');
+    span.className = 'cm-json1-presence';
+    return span;
+  }
+
+  ignoreEvent() {
+    return false;
+  }
+}
+
+const presenceTheme = EditorView.baseTheme({
+  '.cm-json1-presence': {
+    position: 'relative',
+    borderLeft: '1px solid black',
+    borderRight: '1px solid black',
+    marginLeft: '-1px',
+    marginRight: '-1px',
+    boxSizing: 'border-box',
+    display: 'inline',
+  },
+});

--- a/src/json1PresenceDisplay.js
+++ b/src/json1PresenceDisplay.js
@@ -1,0 +1,24 @@
+import { ViewPlugin } from '@codemirror/view';
+
+// Deals with receiving the broadcas from other clients and displaying them.
+//
+// Inspired by
+//  * https://github.com/yjs/y-codemirror.next/blob/main/src/y-remote-selections.js
+//  * https://codemirror.net/examples/decoration/
+//  * https://github.com/share/sharedb/blob/master/examples/rich-text-presence/client.js
+export const json1PresenceDisplay = ({ path, docPresence }) =>
+  ViewPlugin.fromClass(
+    class {
+      constructor(view) {
+        //this.decorations = [];
+        docPresence.on('receive', (id, presence) => {
+          console.log('received presence ' + JSON.stringify(presence));
+        });
+      }
+
+      //update(update) {}
+    },
+    {
+      //decorations: (v) => v.decorations,
+    }
+  );

--- a/src/json1PresenceDisplay.js
+++ b/src/json1PresenceDisplay.js
@@ -7,7 +7,8 @@ import {
 import { Annotation, RangeSet } from '@codemirror/state';
 import { randomId } from './randomId';
 
-// Deals with receiving the broadcas from other clients and displaying them.
+// Deals with receiving the broadcasted presence cursor locations
+// from other clients and displaying them.
 //
 // Inspired by
 //  * https://github.com/yjs/y-codemirror.next/blob/main/src/y-remote-selections.js
@@ -110,6 +111,13 @@ class PresenceWidget extends WidgetType {
     const span = document.createElement('span');
     span.setAttribute('aria-hidden', 'true');
     span.className = 'cm-json1-presence';
+
+    // This child is what actually displays the presence.
+    // Nested so that the layout is not impacted.
+    //
+    // The initial attempt using the top level span to render
+    // the cursor caused a wonky layout with adjacent characters shifting
+    // left and right by 1 pixel or so.
     span.appendChild(document.createElement('div'));
     return span;
   }

--- a/src/randomId.js
+++ b/src/randomId.js
@@ -1,0 +1,2 @@
+// Generate a random ID string consisting of digits.
+export const randomId = () => Math.floor(Math.random() * 10000000000) + '';

--- a/test/index.html
+++ b/test/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta namde="viewport" content="width=device-width" />
-    <title>Test dvdsPage</title>
+    <title>Test Page</title>
   </head>
 
   <body></body>

--- a/test/index.html
+++ b/test/index.html
@@ -5,6 +5,5 @@
     <meta namde="viewport" content="width=device-width" />
     <title>Test Page</title>
   </head>
-
   <body></body>
 </html>


### PR DESCRIPTION
Closes #16

![image](https://user-images.githubusercontent.com/68416/224024862-884821ad-983f-4bd8-9cee-7f0f15f11279.png)

First pass of the feature only.

Summary of changes:
 * Set up ShareDB `LocalPresence` instance
 * Listen for changes in CodeMirror
 * Broadcast presence using ShareDB API
 * Display the remote presence
 * Tested multiple connections (had to pass the `sort` arg to `Decoration.set` to fix this)
 * Tested editing after receiving presence. Had to add a `setTimeout` before dispatching the change to fix this, so there are not synchronous nested CodeMirror updates. This feels like somewhat of a hack, but not sure a better way.
 * Tested that presence cursors are transformed correctly when editing
 * Tested that presence cursors work across newlines

Current limitations:
 * Everyone's cursor is yellow
 * Does not handle removing presence yet
 * Does not yet support range selections (only the start of the selection is displayed remotely, for now)