### PR TITLE
Adopt .prettierrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "test": "npm run build; cd test; node ../cli.js",
-    "prettier": "prettier {*.*,**/*.*} --single-quote --write",
+    "prettier": "prettier {*.*,**/*.*} --write",
     "dev": "vite",
     "build": "vite build",
     "build-release": "vite build --mode release",


### PR DESCRIPTION
This change makes it so that any tooling around Prettier will use the same configuration.

This will avoid future accidental formatting changes in PRs, such as [this change to App.js](https://github.com/vizhub-core/vzcode/pull/85/files/ec2c2c3731a491191164cbcf96859126eacd7d0f#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661).

Specifically, this change makes the VSCode Prettier plugin do the same thing as our `npm run prettier` script, so no matter how we invoke Prettier the results should be the same.