### PR TITLE
Add contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
     "Data",
     "Visualization"
   ],
-  "author": "Curran Kelleher",
+  "contributors": [
+    "Curran Kelleher",
+    "Anooj Pai"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/vizhub-core/vzcode/issues"


### PR DESCRIPTION
Adds @Anooj-Pai as a contributor in `package.json`.

The original proposed change was to change `"author"` to `"authors"`, but on further research, there is no such supported field called `"authors"`, but according to https://docs.npmjs.com/cli/v9/configuring-npm/package-json#people-fields-author-contributors there is a supported field called `"contributors"`.

Not sure if this is correct usage (not sure if each package should have `"author"` defined as well...), but probably it's fine?