### PR TITLE
Added the feature to close active tab with shortcut #156

### DIFF
--- a/src/client/TabList/index.tsx
+++ b/src/client/TabList/index.tsx
@@ -75,7 +75,6 @@ export const TabList = ({
       if (event.altKey == true) {
         if (event.key == 'w') {
           closeTab(activeFileId);
-          console.log(`Key pressed: ${event.key}`);
         }
       }
     },


### PR DESCRIPTION
Closes #156 

Currently working with alt+w to perform the shortcut but can be changed if we want a different keybinding. This logic and use of shortcuts can be expanded upon and we can add more shortcuts to perform more actions within the editor. Or we could also add the feature for users to create their own shortcuts.