### PR TITLE
File delete bug fix

### DIFF
--- a/src/client/TabList/index.tsx
+++ b/src/client/TabList/index.tsx
@@ -91,6 +91,13 @@ export const TabList = ({
       );
     };
   }, [handleKeyPress]);
+  //Checks the current state of the tablist and if it is an invalid file it removes it from the files array.
+  for (let i = 0; i < tabList.length; i++) {
+    if (files[tabList[i]] == undefined) {
+      closeTab(tabList[i]);
+      tabList = tabList.splice(i, i);
+    }
+  }
   return (
     <div className="vz-tab-list">
       {files &&


### PR DESCRIPTION
Close #40 
This issue was rather difficult to find what was causing it. The attached image highlights which line was creating a problem. What is happening is when you delete a file that has  itself open it was improperly removing itself from the tab list. This was resulting in you searching through the files array for an object that does not exist. There may exist a better solution for this problem however this "hardcoded" approach seems to work for now. Furthermore, I was unable to get a react hook to properly work with my code so if someone can think of the correct syntax for it that would be appreciated(I attempted to use useEffect with the dependencies closeTab, files, tabList however it was improperly calling and the error still occurred).
![Screenshot 2023-09-21 023401](https://github.com/vizhub-core/vzcode/assets/28715761/083ac382-a441-4a2e-88fd-8159f32250ef)
