### PR TITLE
Add rotate interactive widget

### DIFF
--- a/src/client/CodeEditor/widgets.ts
+++ b/src/client/CodeEditor/widgets.ts
@@ -104,8 +104,38 @@ export const widgets = ({
           window.open(text);
         },
       },
+
+      //Set rotation to the angle between the x-axis and a line from the word "rotate" to the mouse pointer  (while dragging).
+      //The rotation is in range (-180,180] 
+      {
+        regexp: /rotate\(-?\d*\.?\d*\)/g,
+        cursor: 'move',
+        onDragStart(text, setText, e) {
+          rotationOrigin = { x: e.screenX, y: e.screenY };
+        },
+
+        onDrag(text, setText, e) {
+          if (rotationOrigin == null) return;
+          //Calculate the angle between the x axis and a line from where the user first clicks to the current location of the mouse.
+          setText(
+            `rotate(${Math.round(
+              (Math.atan2(
+                rotationOrigin.y - e.screenY,
+                e.screenX - rotationOrigin.x,
+              ) *
+                180) /
+                Math.PI,
+            )})`,
+          );
+        },
+        onDragEnd(text, setText) {
+          rotationOrigin = null;
+        },
+      },
     ],
   });
+
+var rotationOrigin: { x: number; y: number } = null;
 
 const hex2RGB = (hex: string): [number, number, number] => {
   const v = parseInt(hex.substring(1), 16);

--- a/src/client/CodeEditor/widgets.ts
+++ b/src/client/CodeEditor/widgets.ts
@@ -138,7 +138,7 @@ export const widgets = ({
   });
 
 
-var rotationOrigin: { x: number; y: number } = null;
+let rotationOrigin: { x: number; y: number } = null;
 
 // Inspired by https://github.com/replit/codemirror-interact/blob/master/dev/index.ts#L108
 const hex2RGB = (hex: string): [number, number, number] => {

--- a/test/sampleDirectories/kitchenSink/widgetTest1.js
+++ b/test/sampleDirectories/kitchenSink/widgetTest1.js
@@ -7,6 +7,22 @@ let b = vec2(181, 110);
 
 
 */
+
+var my_transform = d3Transform().translate([60, 60]).rotate(-28);
+
+var group = svg.append("g").attr("transform", my_transfornm);
+
 let a = rgb(236, 24, 24);
 
 let c = false;
+
+let someHTML = (
+  <div id="svgcontainer">
+    <svg width="300" height="300">
+      <g transform="translate(60,60) rotate(-89)">
+        <rect x="20" y="20" width="60" height="60" fill="green"></rect>
+        <circle cx="0" cy="0" r="30" fill="red" />
+      </g>
+    </svg>
+  </div>
+);


### PR DESCRIPTION
This allows the user to move their mouse around rotate(x) to change the value of x. This can be used to rotate SVGs (D3). This commit also contains the color picker and vec2 widgets commit. We did not discuss this feature in the meeting, but I thought it was worth exploring after I finished the previous commit.