### PR TITLE
WIP Delete Confirmation Modal

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -232,12 +232,8 @@ function App() {
     [submitOperation, closeTab],
   );
 
-  // TODO prompt the user "Are you sure?"
   const handleDeleteFileClick = useCallback(
-    (fileId: FileId, event: React.MouseEvent) => {
-      // Stop propagation so that the outer listener doesn't fire,
-      // which would try to open this file in a tab.
-      event.stopPropagation();
+    (fileId: FileId) => {
       deleteFile(fileId);
     },
     [deleteFile],

--- a/src/client/Sidebar/ConfirmationBox.jsx
+++ b/src/client/Sidebar/ConfirmationBox.jsx
@@ -2,42 +2,33 @@ import React from 'react';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 
-export const ConfirmationBox = (props) => {
-  return (
-    <div className="modal-overlay">
-      <div className="modal-container">
-        <Modal
-          show={props.show}
-          close={props.onClose}
-          confirm={props.onConfirm}
-          centered
-        >
-          <Modal.Header closeButton onClick={props.onClose}>
-            <Modal.Title>Delete File</Modal.Title>
-          </Modal.Header>
+// Inspired by https://react-bootstrap.netlify.app/docs/components/modal/#live-demo
+export const ConfirmationBox = ({
+  show,
+  onClose,
+  onConfirm,
+}) => (
+  <Modal
+    show={show}
+    onHide={onClose}
+    confirm={onConfirm}
+    centered
+  >
+    <Modal.Header closeButton onClick={onClose}>
+      <Modal.Title>Delete File</Modal.Title>
+    </Modal.Header>
 
-          <Modal.Body>
-            <p>
-              Are you sure you want to delete this file?
-            </p>
-          </Modal.Body>
+    <Modal.Body>
+      <p>Are you sure you want to delete this file?</p>
+    </Modal.Body>
 
-          <Modal.Footer>
-            <Button
-              variant="primary"
-              onClick={props.onConfirm}
-            >
-              Yes
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={props.onClose}
-            >
-              No
-            </Button>
-          </Modal.Footer>
-        </Modal>
-      </div>
-    </div>
-  );
-};
+    <Modal.Footer>
+      <Button variant="primary" onClick={onConfirm}>
+        Yes
+      </Button>
+      <Button variant="secondary" onClick={onClose}>
+        No
+      </Button>
+    </Modal.Footer>
+  </Modal>
+);

--- a/src/client/Sidebar/ConfirmationBox.jsx
+++ b/src/client/Sidebar/ConfirmationBox.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+
+export const ConfirmationBox = (props) => {
+  return (
+    <div className="modal-overlay">
+      <div className="modal-container">
+        <Modal
+          show={props.show}
+          close={props.onClose}
+          confirm={props.onConfirm}
+          centered
+        >
+          <Modal.Header closeButton onClick={props.onClose}>
+            <Modal.Title>Delete File</Modal.Title>
+          </Modal.Header>
+
+          <Modal.Body>
+            <p>
+              Are you sure you want to delete this file?
+            </p>
+          </Modal.Body>
+
+          <Modal.Footer>
+            <Button
+              variant="primary"
+              onClick={props.onConfirm}
+            >
+              Yes
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={props.onClose}
+            >
+              No
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    </div>
+  );
+};

--- a/src/client/Sidebar/DirectoryListing.tsx
+++ b/src/client/Sidebar/DirectoryListing.tsx
@@ -18,10 +18,7 @@ export const DirectoryListing = ({
   path: string;
   children: Array<FileTree | FileTreeFile>;
   handleRenameFileClick: (fileId: string) => void;
-  handleDeleteFileClick: (
-    fileId: string,
-    event: React.MouseEvent,
-  ) => void;
+  handleDeleteFileClick: (fileId: string) => void;
   handleFileClick: (fileId: string) => void;
   isDirectoryOpen: (path: string) => boolean;
   toggleDirectory: (path: string) => void;

--- a/src/client/Sidebar/FileListing.tsx
+++ b/src/client/Sidebar/FileListing.tsx
@@ -12,10 +12,7 @@ export const FileListing = ({
   name: string;
   fileId: FileId;
   handleRenameFileClick: (fileId: FileId) => void;
-  handleDeleteFileClick: (
-    fileId: FileId,
-    event: React.MouseEvent,
-  ) => void;
+  handleDeleteFileClick: (fileId: FileId) => void;
   handleFileClick: (fileId: FileId) => void;
 }) => {
   const handleClick = useCallback(() => {
@@ -24,12 +21,7 @@ export const FileListing = ({
 
   const handleDeleteClick = useCallback(
     (event) => {
-      const x = window.confirm(
-        'Are you sure you want to delete?',
-      );
-      if (x === true) {
-        handleDeleteFileClick(fileId, event);
-      }
+      handleDeleteFileClick(fileId);
     },
     [fileId, handleDeleteFileClick],
   );

--- a/src/client/Sidebar/Item.jsx
+++ b/src/client/Sidebar/Item.jsx
@@ -1,4 +1,10 @@
-import { useState, useCallback } from 'react';
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
+import { ConfirmationBox } from './confirmationBox';
 
 export const Item = ({
   children,
@@ -7,6 +13,52 @@ export const Item = ({
   handleDeleteClick,
 }) => {
   const [isHovered, setIsHovered] = useState(false);
+
+  const [showModal, setShowModal] = useState(false);
+
+  //Function to open the modal
+  const handleModalOpen = useCallback(() => {
+    setShowModal(true);
+  }, []);
+
+  //Function to close the modal
+  const handleModalClose = useCallback(() => {
+    setShowModal(false);
+  }, []);
+
+  //function to handle confirmation on modal
+  const handleConfirmModal = useCallback(() => {
+    setShowModal(false);
+    handleDeleteClick();
+  }, [handleDeleteClick]);
+
+  //function to close Modal if anywhere else on the screen is clicked
+  const outsideClickHandler = useCallback((ref) => {
+    useEffect(() => {
+      //check if clicked outside
+      function handleClickOutside(event) {
+        if (
+          ref.current &&
+          !ref.current.contains(event.target)
+        ) {
+          handleModalClose();
+        }
+      }
+      document.addEventListener(
+        'click',
+        handleClickOutside,
+      );
+      return () => {
+        document.removeEventListener(
+          'click',
+          handleClickOutside,
+        );
+      };
+    }, [ref]);
+  }, []);
+
+  const wrapperRef = useRef(null);
+  outsideClickHandler(wrapperRef);
 
   const handleMouseEnter = useCallback(() => {
     setIsHovered(true);
@@ -32,11 +84,20 @@ export const Item = ({
             onClick={handleRenameClick}
           ></i>
           <i
+            ref={wrapperRef}
             className="bx bx-trash"
             style={{ color: '#eb336c' }}
-            onClick={handleDeleteClick}
+            onClick={handleModalOpen}
           ></i>
         </div>
+      ) : null}
+
+      {showModal ? (
+        <ConfirmationBox
+          show={showModal}
+          onClose={handleModalClose}
+          onConfirm={handleConfirmModal}
+        />
       ) : null}
     </div>
   );

--- a/src/client/Sidebar/Item.tsx
+++ b/src/client/Sidebar/Item.tsx
@@ -4,7 +4,7 @@ import {
   useEffect,
   useRef,
 } from 'react';
-import { ConfirmationBox } from './confirmationBox';
+import { ConfirmationBox } from './ConfirmationBox';
 
 export const Item = ({
   children,
@@ -16,49 +16,21 @@ export const Item = ({
 
   const [showModal, setShowModal] = useState(false);
 
-  //Function to open the modal
+  // Function to open the delete file confirmation modal
   const handleModalOpen = useCallback(() => {
     setShowModal(true);
   }, []);
 
-  //Function to close the modal
+  // Function to close the modal
   const handleModalClose = useCallback(() => {
     setShowModal(false);
   }, []);
 
-  //function to handle confirmation on modal
+  // Function to handle confirmation on modal
   const handleConfirmModal = useCallback(() => {
     setShowModal(false);
     handleDeleteClick();
   }, [handleDeleteClick]);
-
-  //function to close Modal if anywhere else on the screen is clicked
-  const outsideClickHandler = useCallback((ref) => {
-    useEffect(() => {
-      //check if clicked outside
-      function handleClickOutside(event) {
-        if (
-          ref.current &&
-          !ref.current.contains(event.target)
-        ) {
-          handleModalClose();
-        }
-      }
-      document.addEventListener(
-        'click',
-        handleClickOutside,
-      );
-      return () => {
-        document.removeEventListener(
-          'click',
-          handleClickOutside,
-        );
-      };
-    }, [ref]);
-  }, []);
-
-  const wrapperRef = useRef(null);
-  outsideClickHandler(wrapperRef);
 
   const handleMouseEnter = useCallback(() => {
     setIsHovered(true);
@@ -84,7 +56,6 @@ export const Item = ({
             onClick={handleRenameClick}
           ></i>
           <i
-            ref={wrapperRef}
             className="bx bx-trash"
             style={{ color: '#eb336c' }}
             onClick={handleModalOpen}
@@ -92,13 +63,11 @@ export const Item = ({
         </div>
       ) : null}
 
-      {showModal ? (
-        <ConfirmationBox
-          show={showModal}
-          onClose={handleModalClose}
-          onConfirm={handleConfirmModal}
-        />
-      ) : null}
+      <ConfirmationBox
+        show={showModal}
+        onClose={handleModalClose}
+        onConfirm={handleConfirmModal}
+      />
     </div>
   );
 };

--- a/src/client/Sidebar/Listing.tsx
+++ b/src/client/Sidebar/Listing.tsx
@@ -18,10 +18,7 @@ export const Listing = ({
 }: {
   entity: FileTree | FileTreeFile;
   handleRenameFileClick: (fileId: FileId) => void;
-  handleDeleteFileClick: (
-    fileId: FileId,
-    event: React.MouseEvent,
-  ) => void;
+  handleDeleteFileClick: (fileId: FileId) => void;
   handleFileClick: (fileId: FileId) => void;
   isDirectoryOpen: (path: string) => boolean;
   toggleDirectory: (path: string) => void;

--- a/src/client/Sidebar/index.tsx
+++ b/src/client/Sidebar/index.tsx
@@ -25,10 +25,7 @@ export const Sidebar = ({
   files: Files;
   createFile?: () => void;
   handleRenameFileClick?: (fileId: FileId) => void;
-  handleDeleteFileClick?: (
-    fileId: FileId,
-    event: React.MouseEvent,
-  ) => void;
+  handleDeleteFileClick?: (fileId: FileId) => void;
   handleFileClick?: (fileId: FileId) => void;
   setIsSettingsOpen?: (isSettingsOpen: boolean) => void;
   isDirectoryOpen?: (path: string) => boolean;


### PR DESCRIPTION
Implemented the modal confirmation box as was requested in #199 . 

I added a couple of new functions in Item.jsx to handle opening and closing the modal. 

“handleDeleteFileClick” no longer accepts event as an argument as it is no longer called as a result of a button click.

Files referencing "handleDeleteFileClick" were updated to reflect this change. 

Still new to all of this. Please let me know if there is anything that could be improved on or anything I missed. :)