### PR TITLE
172 usability improvements tab list goes offscreen

### DIFF
--- a/src/client/TabList/style.scss
+++ b/src/client/TabList/style.scss
@@ -1,4 +1,3 @@
-// see https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x for more info 
 .vz-tab-list {
   display: flex;
   background-color: rgb(37, 37, 38);

--- a/src/client/TabList/style.scss
+++ b/src/client/TabList/style.scss
@@ -1,6 +1,10 @@
+// see https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x for more info 
 .vz-tab-list {
   display: flex;
   background-color: rgb(37, 37, 38);
+
+  //when the tab list becomes too large scroll bar appears
+  overflow-x: scroll; 
 
   .tab {
     background: rgb(45, 45, 45);
@@ -17,6 +21,9 @@
     margin-left: 2px;
     margin-right: 2px;
     cursor: pointer;
+
+    //making sure text doesnt wrap within tabs
+    white-space: nowrap;
 
     .tab-close {
       margin-left: 5px;


### PR DESCRIPTION
Added a very simple, and possibly temporary, fix to the tablist going off screen. When the length of the tab list exceeds the width of the editor a scroll bar appears.