### PR TITLE
Widgets make color picker live updating

### DIFF
--- a/src/client/CodeEditor/widgets.ts
+++ b/src/client/CodeEditor/widgets.ts
@@ -15,10 +15,50 @@ export const widgets = ({
 }) =>
   interact({
     rules: [
+      // hex color picker
+      // Inspired by https://github.com/replit/codemirror-interact/blob/master/dev/index.ts#L71
+      {
+        regexp: /\"\#([0-9]|[A-F]|[a-f]){6}\"/g,
+        cursor: 'pointer',
+        onClick(text, setText, e) {
+          const res =
+            /\"(?<hex>\#([0-9]|[A-F]|[a-f]){6})\"/.exec(
+              text,
+            );
+          const startingColor = res.groups?.hex;
+
+          const sel = document.createElement('input');
+          sel.type = 'color';
+
+          sel.value = startingColor.toLowerCase();
+
+          //valueIsUpper maintains style of user's code. It keeps the case of a-f the same case as the original."
+          const valueIsUpper =
+            startingColor.toUpperCase() == startingColor;
+
+          const updateHex = (e: Event) => {
+            const el = e.target as HTMLInputElement;
+
+            if (el.value) {
+              setText(
+                `"${
+                  valueIsUpper
+                    ? el.value.toUpperCase()
+                    : el.value
+                }"`,
+              );
+            }
+            sel.removeEventListener('change', updateHex);
+          };
+          sel.addEventListener('change', updateHex);
+          sel.click();
+        },
+      },
+
       // a rule for a number dragger
       {
         // the regexp matching the value
-        regexp: /-?\b\d+\.?\d*\b/g,
+        regexp: /(?<!\#)-?\b\d+\.?\d*\b/g,
         // set cursor to "ew-resize" on hover
         cursor: 'ew-resize',
         // change number value based on mouse X movement on drag
@@ -43,7 +83,7 @@ export const widgets = ({
           }
         },
       },
-      //vec2 slider
+      // vec2 slider
       // Inspired by: https://github.com/replit/codemirror-interact/blob/master/dev/index.ts#L61
       {
         regexp:
@@ -64,7 +104,7 @@ export const widgets = ({
           );
         },
       },
-      //color picker
+      // rgb color picker
       // Inspired by https://github.com/replit/codemirror-interact/blob/master/dev/index.ts#L71
       //TODO: create color picker for hsl colors
       {
@@ -82,6 +122,7 @@ export const widgets = ({
           //sel will open the color picker when sel.click is called.
           const sel = document.createElement('input');
           sel.type = 'color';
+
           if (!isNaN(r + g + b))
             sel.value = rgb2Hex(r, g, b);
 
@@ -97,7 +138,7 @@ export const widgets = ({
           sel.addEventListener('change', updateRGB);
           sel.click();
         },
-      },
+      },     
       // url clicker
       {
         regexp: /https?:\/\/[^ "]+/g,

--- a/src/client/CodeEditor/widgets.ts
+++ b/src/client/CodeEditor/widgets.ts
@@ -48,9 +48,8 @@ export const widgets = ({
                 }"`,
               );
             }
-            sel.removeEventListener('change', updateHex);
           };
-          sel.addEventListener('change', updateHex);
+          sel.addEventListener('input', updateHex);
           sel.click();
         },
       },
@@ -138,7 +137,7 @@ export const widgets = ({
           sel.addEventListener('change', updateRGB);
           sel.click();
         },
-      },     
+      },
       // url clicker
       {
         regexp: /https?:\/\/[^ "]+/g,

--- a/test/sampleDirectories/kitchenSink/hexContinousTest1.js
+++ b/test/sampleDirectories/kitchenSink/hexContinousTest1.js
@@ -1,0 +1,7 @@
+let a = 5;
+
+let color = "#3E5170";
+
+let rgbColour = rgb(178, 52, 52);
+
+let aString = "make sure this stays";

--- a/test/sampleDirectories/kitchenSink/widgetTest1.js
+++ b/test/sampleDirectories/kitchenSink/widgetTest1.js
@@ -3,6 +3,8 @@
 let aColor = rgb(81, 89, 194);
 
 let b = vec2(181, 110);
+
+let hexColor = "#ABCDE4"
 /*
 
 


### PR DESCRIPTION
This pull request includes the commit that adds the hex color picker interactive widget.

So far, this pull request makes it so hex colors update in the code automatically as the user uses the color picker.

However, implementing this feature for colors in the format rgb(123, 4, 28) would require creating our own version of codemirror-interact. The existing version uses the following steps:

1. Find the section of code the user wants to edit using regex and the mouse's location.
2. Give the onClick function a function that sets the text for the section previously found
3. My code then calls the setText function whenever the user changes the color in the color picker.

These steps (particularly the first two) do not allow the section of code to change. This breaks the feature because rgb( , , ) can have multiple lengths, depending on how many digits there are in the color values. This leads to text after rgb( , , ) being deleted or extra characters being outputted at the end of the string.

It seems to me the best course of action is to add this feature for hex values, not for rgb values, and then focus on showing colors in the code (or another feature).