### PR TITLE
Un-adopt react-select, upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,12 @@
         "@codemirror/lang-css": "^6.2.1",
         "@codemirror/lang-html": "^6.4.6",
         "@codemirror/lang-javascript": "^6.2.1",
-        "@codemirror/lang-markdown": "^6.2.1",
+        "@codemirror/lang-markdown": "^6.2.2",
         "@codemirror/state": "^6.2.1",
         "@codemirror/theme-one-dark": "^6.1.2",
         "@replit/codemirror-interact": "^6.3.0",
         "@teamwork/websocket-json-stream": "^2.0.0",
-        "@uiw/codemirror-themes-all": "^4.21.18",
+        "@uiw/codemirror-themes-all": "^4.21.19",
         "codemirror": "^6.0.1",
         "codemirror-ot": "^4.1.0",
         "d3-array": "^3.2.4",
@@ -31,8 +31,8 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.9.0",
         "react-dom": "^18.2.0",
-        "react-select": "^5.7.5",
-        "sharedb": "^4.0.1",
+        "react-select": "^5.7.7",
+        "sharedb": "^4.1.0",
         "sharedb-client-browser": "^4.3.1",
         "ws": "^8.14.2"
       },
@@ -40,14 +40,14 @@
         "vzcode": "src/server/index.js"
       },
       "devDependencies": {
-        "@types/react": "^18.2.23",
-        "@types/react-dom": "^18.2.8",
+        "@types/react": "^18.2.28",
+        "@types/react-dom": "^18.2.13",
         "@vitejs/plugin-react": "^4.1.0",
         "prettier": "^3.0.3",
-        "sass": "^1.68.0",
+        "sass": "^1.69.2",
         "typescript": "^5.2.2",
-        "vite": "^4.4.9",
-        "vitest": "^0.34.5"
+        "vite": "^4.4.11",
+        "vitest": "^0.34.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@codemirror/lang-markdown": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.2.1.tgz",
-      "integrity": "sha512-Tpk1+CllQ/KU27AYixsxvtqqQS2xYfLEUiBEyyzO+Y9/0LfI2oB1qM2cMhy0D7oRnG0ZSAy9qcYniZc9VtlIxg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.2.2.tgz",
+      "integrity": "sha512-wmwM9Y5n/e4ndU51KcYDaQnb9goYdhXjU71dDW9goOc1VUTIPph6WKAPdJ6BzC0ZFy+UTsDwTXGWSP370RH69Q==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.7.1",
         "@codemirror/lang-html": "^6.0.0",
@@ -1019,9 +1019,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.23.tgz",
-      "integrity": "sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==",
+      "version": "18.2.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.28.tgz",
+      "integrity": "sha512-ad4aa/RaaJS3hyGz0BGegdnSRXQBkd1CCYDCdNjBPg90UUpLgo+WlJqb9fMYUxtehmzF3PJaTWqRZjko6BRzBg==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1029,9 +1029,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.8",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.8.tgz",
-      "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
+      "version": "18.2.13",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.13.tgz",
+      "integrity": "sha512-eJIUv7rPP+EC45uNYp/ThhSpE16k22VJUknt5OLoH9tbXoi8bMhwLf5xRuWMywamNbWzhrSmU7IBJfPup1+3fw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -1073,281 +1073,281 @@
       }
     },
     "node_modules/@uiw/codemirror-theme-abcdef": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abcdef/-/codemirror-theme-abcdef-4.21.18.tgz",
-      "integrity": "sha512-jobuck5/PfoZtHUwHc62jHMGLHVj6bS6HixOTKAg3N85Q0Fl9+E/rNTZ6hAeq6jFPBEMSxVoj2yz75NDxk+Qpw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abcdef/-/codemirror-theme-abcdef-4.21.19.tgz",
+      "integrity": "sha512-GB+aR5zgTkEDir8AWTCct4h5MdDyWCLtcGm74u6mli65qQWq7ng1sdcWzkFw7/NDXUi0tPwDZ8ZArIzCmU7olA==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-abyss": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abyss/-/codemirror-theme-abyss-4.21.18.tgz",
-      "integrity": "sha512-/7/GKGn5H25FE+dMYM49FkCoKhU2mc625KAl1QKoxcuN6pBhnDtfaSDEb6tnCqaPnkjCoJ2sQztifTJBrmuYyQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abyss/-/codemirror-theme-abyss-4.21.19.tgz",
+      "integrity": "sha512-q7ttP5rNd9nJ541SWs6zc3BRw9EPCS29KPvBCvYwKd3rqyq9HLtpZf2r2hgw2eQSWbUFp54hH2UYrhP8jSIUOg==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-androidstudio": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-androidstudio/-/codemirror-theme-androidstudio-4.21.18.tgz",
-      "integrity": "sha512-+MUBh1wRmdN7P0flglBoZ6wxZld3u8rqovlF7y7EYhde7KOdmaVvM55QkYD16FEjNisCTTZ3z0A7tk7OzP1jaw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-androidstudio/-/codemirror-theme-androidstudio-4.21.19.tgz",
+      "integrity": "sha512-Pk3c8j5+IJ1E6iaUNiI2YkAGOXo7pGiqtJdiPQIfsbGQ/kL4RdjPfbuuevvC5bLtE6zOyjll4plOajL4qMPvzg==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-andromeda": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-andromeda/-/codemirror-theme-andromeda-4.21.18.tgz",
-      "integrity": "sha512-GzJ40zeobFxyu4kyHB2/7T/s8mQ3j7YxMTpEY1t8HzPTTeaCn0/9PmLZ4IBHY4/hFVWCENZkQ74SAcJAGo9g0w==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-andromeda/-/codemirror-theme-andromeda-4.21.19.tgz",
+      "integrity": "sha512-X+wAfkULUCuEUBEe9FFYF/aK0QOse7YEDXpoUzvsBoijlvp2HGTtLYlCul2h5YQ5WbEQGiSB8EVcaqcWoFLWzQ==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-atomone": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-atomone/-/codemirror-theme-atomone-4.21.18.tgz",
-      "integrity": "sha512-NPYlLkvs10b/+WubwPrwwPgzNdDgrCLC/mDlW4f/DKSSefdteUb8ReA6DUUCJCJiVoJPDjMwsqtCFUVoGU7JkA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-atomone/-/codemirror-theme-atomone-4.21.19.tgz",
+      "integrity": "sha512-aY302zmP/hro47UammNIZj9DLZBuUHzVgOLqaTUAiUzqvQ721ktL8qN4USRO3H1Bkn1W/+UuKFQTMyliFDkBKQ==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-aura": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-aura/-/codemirror-theme-aura-4.21.18.tgz",
-      "integrity": "sha512-2fXTT2t7K9Ri2M5Fek8XTOqkukAP50ocjKQnNjvmrjJx2yC07/Li58eeVHAX3xeo7WcaqdlEAftGzFYxlI5HaQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-aura/-/codemirror-theme-aura-4.21.19.tgz",
+      "integrity": "sha512-n+sZM3VDjGz2quovwO44Et21kQRJ5Ow4ZutZCimaIH6Oe7+++yNgqFXMqYs3M983CiIJX6r7ZKuawHW0XlV7Tw==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-basic": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-basic/-/codemirror-theme-basic-4.21.18.tgz",
-      "integrity": "sha512-4aW0i07AYQRNFr978HOyLMTHsOeUbj1OQlDKhL6o8LXXn7I3qAD9sS/hYJIdeiQVaDCI5s+JZgzavxbtvI+exA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-basic/-/codemirror-theme-basic-4.21.19.tgz",
+      "integrity": "sha512-w+UxYdZql48iFwJRIuaG6xPBKJlmUf+I01Fe0QUC1TmeLr/PXqwb2NAuknZxi4S7excRc6Zg2uFoLqpzZ0ADxQ==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-bbedit": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bbedit/-/codemirror-theme-bbedit-4.21.18.tgz",
-      "integrity": "sha512-SACfPbC+WEk7vrvY6sUnR3xVSjXvHjZjb3zi0XY/weRVUMMG4AnIkm0SHEtGct3VobjeuUlSisRg+PZVTDZ6jg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bbedit/-/codemirror-theme-bbedit-4.21.19.tgz",
+      "integrity": "sha512-Ps2qS4+FQB0tl/wUxzHBPIR9YBF7IzIDXjwxN0z0ieORkzDlnbzwqBHKNWWEAggD92DW3ZP9kdNitck7keMCpg==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-bespin": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bespin/-/codemirror-theme-bespin-4.21.18.tgz",
-      "integrity": "sha512-SJKOMaGZzO+mo3IUmDK0CV6pHKAxYFIASHYdcp70xe7/UY0D+NwI5+KQYNk9iEnu5Sttswa//y6ZHHNJ4uYTQw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bespin/-/codemirror-theme-bespin-4.21.19.tgz",
+      "integrity": "sha512-4oeQ21+/WD2pKvxfv2Nl4UpDyglhLzLivIj8oRFOissgGsItOH6Goq/13ChjcQhzc42a5IDKf+HXpkdaXS+18w==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-copilot": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-copilot/-/codemirror-theme-copilot-4.21.18.tgz",
-      "integrity": "sha512-Trr3JYDbw1JZlCglIQH51ct6+8tz2cj3YaCmC5Xat8sRfV+CnyhlE0I3biehUxSPcfrcwxEzWk7P3sJO3duF8w==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-copilot/-/codemirror-theme-copilot-4.21.19.tgz",
+      "integrity": "sha512-C/m4U/PiKHn0GyhNeWWcX4zyMluw5MJQOpUGoUuukbEwNE8u95K3WthrBEQzEV6FcJjLt+WpJbXcdTCZ0ftaHg==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-darcula": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-darcula/-/codemirror-theme-darcula-4.21.18.tgz",
-      "integrity": "sha512-nOY7o3X2PbwHpuD3AWU7JhGiGiGD1cwEIdmdqjdAOliti8bTMdSpYhV41VrwTTTJOQLRZlYeQeMAZh43AkxFwg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-darcula/-/codemirror-theme-darcula-4.21.19.tgz",
+      "integrity": "sha512-TLosR1ZLM6CQb5hENzwiTwHdSHGOU67QhBGZC9+UuKK8PEit2wBrz+xVIBJ5glpsdXRYyVZQixtJFUPPxSH6fw==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-dracula": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-dracula/-/codemirror-theme-dracula-4.21.18.tgz",
-      "integrity": "sha512-5kuf8tlZ8Be/jv/5nsxKNb6e32/UgIii7ws/TNXBv5DkXpsqafxfnEL43HOjTh71wQJOYpnBLWVTZjV0GRGe0A==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-dracula/-/codemirror-theme-dracula-4.21.19.tgz",
+      "integrity": "sha512-/OqprQhShd3l/c5hDAtmnocOuMWiuy6nxn42isllyF7AGcThHGsXlYpHMpVaVLONsL8lBj2CnUoiDXgy35pIgQ==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-duotone": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-duotone/-/codemirror-theme-duotone-4.21.18.tgz",
-      "integrity": "sha512-e3q2gP6HmwO4HqCvr0D1iciWd/aAfkMQVTkN4U9JdrMkQGR7OKr822Y3IVbPtFx6QdftY/MKv8D1OUfxqz/YQA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-duotone/-/codemirror-theme-duotone-4.21.19.tgz",
+      "integrity": "sha512-T+Kuz9TJyI3MbqHW9n58FVCznEHIgKIrJlZh+ah6nNsGNUVOI4xdn6wLAauEyDD4uTL7ekI/Q/yI4YyebGhXmQ==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-eclipse": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-eclipse/-/codemirror-theme-eclipse-4.21.18.tgz",
-      "integrity": "sha512-8rNtN+peNDq8Wq3FpBfxLHs4qclQvY29xZuMw9C879prkNFqRHyqQ9kHMQW4DryanWZCi6BpKQRUE0TZUnC7lQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-eclipse/-/codemirror-theme-eclipse-4.21.19.tgz",
+      "integrity": "sha512-YATAOURKG/t2ZPbkkTBBjiJVuA3z/kc5VBpvVopp+BLcWjUyjohLFRAzxuxD6kS3PYE6h9oVEGHBXejnpXTDQg==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-github": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-github/-/codemirror-theme-github-4.21.18.tgz",
-      "integrity": "sha512-RviQ3WaG96DTaz2WP0vi3IGPCeaxRflglhv3hwYXrG/u5vRIbddfDB5R+A+Sr5HCKRGdPMpSo5xfKjwdI05LzQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-github/-/codemirror-theme-github-4.21.19.tgz",
+      "integrity": "sha512-VgtASDyTHH7IoVb9gI6AFyclwnQgCCWIEFm8v/QhENqwumpU2ar5P10usT4agk5WOWiy1kM2YS/MBCnfe0wutw==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-gruvbox-dark": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-gruvbox-dark/-/codemirror-theme-gruvbox-dark-4.21.18.tgz",
-      "integrity": "sha512-TIXi/lkM6KzBWgLFc6Pz8iXwvyDZr2K1tuqygZYUJjWCdeKsl4udrvm0mqmJLEotqyz17qJiDIc7vodu3YGjSw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-gruvbox-dark/-/codemirror-theme-gruvbox-dark-4.21.19.tgz",
+      "integrity": "sha512-a4GkHvPvoaFSyQST7wcso2ARjVp9+1pvB5hDybizqSFftH1t6V6Fw/ssw5Ne4TqfFuyasEmCPns5OFWtqNUFPw==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-kimbie": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-kimbie/-/codemirror-theme-kimbie-4.21.18.tgz",
-      "integrity": "sha512-VKSjEdsTlZcVNtG46eZ9gmNhN/PXPwzeA87ZntJPx3CCWRbkp90Pg/Sgcui19ZFlq5kC6f7kqo/mjv+JOGR0sQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-kimbie/-/codemirror-theme-kimbie-4.21.19.tgz",
+      "integrity": "sha512-xd4C8giaF2JjCg8Ob/GaEgsR8Wfz/km48fe+/B7QA2ByB496KP9R4eg2YRz5Qu05tGvVuuTrZD1Pj1rxSsD2dw==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-material": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.21.18.tgz",
-      "integrity": "sha512-a/EZ3ysKaeY9pmcr45eemnqLTcxC5ca67GiM4S+ZSIA4kG+AwwqdrHwtoajCfj4/RQ562b7GrxuXaJgtqPrz0g==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.21.19.tgz",
+      "integrity": "sha512-xS+hyth2Zl4NEKPP3H5JkANj5urCsMF/RrjsowWyxQneOU023rF96OwY+kuZWWLnmwJj4KYBrp7fpk5x5jLgmQ==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-monokai": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai/-/codemirror-theme-monokai-4.21.18.tgz",
-      "integrity": "sha512-uZDQQBLgbYZtqvQDEtlFZyuUuB8rqZrGJIx0P47vTTYy5HnU9FNqnuP0K0IhBm9oEyr/Ts1fHJ6IoovrtK5bJA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai/-/codemirror-theme-monokai-4.21.19.tgz",
+      "integrity": "sha512-PaRM0kks+LKn1uf0l33Z+LF31lvl8S+3vVPy26F9NZwn/ZOhE7UPzkmJ5Vm9KO5ueMPV1Dv2+j4DZTQUiz456Q==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-monokai-dimmed": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai-dimmed/-/codemirror-theme-monokai-dimmed-4.21.18.tgz",
-      "integrity": "sha512-IkJNaIAcEolbnv2QZq2HhHBSDjAUJZz0Aq3Gybp2ifCM1IKkcmGlgG8o7JVpKfn1crq50b1xKaiy4ZRZuOPjhg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai-dimmed/-/codemirror-theme-monokai-dimmed-4.21.19.tgz",
+      "integrity": "sha512-FkQQjZyWGxHeQ0cTRNSV/ezUHgd9ZG4ez6rV1gdJRAxPG4oY/qPOlwyYxWOa/MTI5cOwul5GgYVEmu962zE8Bg==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-noctis-lilac": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-noctis-lilac/-/codemirror-theme-noctis-lilac-4.21.18.tgz",
-      "integrity": "sha512-X2Gxw09qtji/b7e02VX1nTgl5a5XvXwAqkEX5VGmPpJLnnseoe5rHl8/UnK+viVbJ2iwFEobg5RBGiX0ZTmVSg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-noctis-lilac/-/codemirror-theme-noctis-lilac-4.21.19.tgz",
+      "integrity": "sha512-04CcGn4rR71Mt8h6cpLFDDYbgodQij2/uKZ1NxbO1XfBHIeBspn50omxGlPLAKIVv0pKKjespwQhGbI5NUKTZQ==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-nord": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-nord/-/codemirror-theme-nord-4.21.18.tgz",
-      "integrity": "sha512-aYaCQGq/4/gbxRAXQ8L8Wv9qZnRUHzQDyN0Zbc8VVfWfp2NW0CxEw9Do+EriRaVFsBDTBarEiBpjOR7lQkoKUw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-nord/-/codemirror-theme-nord-4.21.19.tgz",
+      "integrity": "sha512-7dJVo7xgopv3KoqdkurxTf1tUX7eVPX12OQNdxE3hl6d+l3taXn2Hjc/4zuLTJ4gaNAe34187GuPxpVHUjbiDA==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-okaidia": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-okaidia/-/codemirror-theme-okaidia-4.21.18.tgz",
-      "integrity": "sha512-kXrvbhupmgd2e4vAJNDLvGEpqZ01NHqJtlVWAlDUUZ8EvezbaPhPvl/7NWXMxYlcHndxPwi4pMFJqHmmEbyjZg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-okaidia/-/codemirror-theme-okaidia-4.21.19.tgz",
+      "integrity": "sha512-uUVG26TVTsVl/nv8MJjpCEpu/5uVMzuG6IyxzUC30+IkQG4V/MTW/AaWsng5pCqjroo1zMvMud/PCSfcSAI2gA==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-quietlight": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-quietlight/-/codemirror-theme-quietlight-4.21.18.tgz",
-      "integrity": "sha512-1aYRWlLJYsfY57Ht7iPEbcrd/h/mh5hIA1YfYZR0n31v5eQOr6i0iNoIcfMAzOT229DDPMeTXC4qPTWlFAt/JA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-quietlight/-/codemirror-theme-quietlight-4.21.19.tgz",
+      "integrity": "sha512-WRbXQRLKPR5qre4yj4MOunBZ1ryRQrvMR2fzwewDTVaNvuq/GDevMRUuwanlZQC3IP1xbOgE99jQH2vCY6t8Ew==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-red": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-red/-/codemirror-theme-red-4.21.18.tgz",
-      "integrity": "sha512-+olzy2PjhEA6i2Ye5CcSjfESzgWuKINa82AZagZ9/p4d427EYTpmRf+BCspcehbI05E9mqyDsUBulFz8yKdwnQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-red/-/codemirror-theme-red-4.21.19.tgz",
+      "integrity": "sha512-/CjajNL4XXusT/9+nuqQjFkx1QMfejdapXCo6+s20xJNfx2OAlTpLtVs08+5a/FJ2HEVbj/ckyjOfn2qbsW8+Q==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-solarized": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-solarized/-/codemirror-theme-solarized-4.21.18.tgz",
-      "integrity": "sha512-igQ2vHPoE8GpeSsU6ZJx2+ZSYG00pXaAf2R/bgK5B1PacJOyJQu8sP83YfwUJRUIm50baxzOvAiwZmoKvLpPSQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-solarized/-/codemirror-theme-solarized-4.21.19.tgz",
+      "integrity": "sha512-m4RMdV3HWDIit84/YtZp1Ua6d1FGD1iN3HKrM0V3FF1SC6o9ZPpIblK05/sl+Rfdv80RuP7as8NGb3fC945kmw==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-sublime": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-sublime/-/codemirror-theme-sublime-4.21.18.tgz",
-      "integrity": "sha512-/zaPbGpk1bXi/144jziLDOIrrgl14WxQYC7G5Yf6yYeWyz1JbbJgyQTaJ+xTNF9FQXL4ft6/oMteWfw+ZzBYjg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-sublime/-/codemirror-theme-sublime-4.21.19.tgz",
+      "integrity": "sha512-UxnLsCoc2mVAfI7AOrgchvbWGcfw3uVO5Ng7MShucbY/3UtMKY6gBJM2CD2w27vRIxV9KWQNacTe3dkuDaIASA==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-tokyo-night": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night/-/codemirror-theme-tokyo-night-4.21.18.tgz",
-      "integrity": "sha512-tXiFjR+J6jxH29PwzFSLCeWnEq1sOSmXWt7umoFu+9q41aZYsQox7kMSCghmy2YHX/IWB16VYDZJzKw1Qicjpg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night/-/codemirror-theme-tokyo-night-4.21.19.tgz",
+      "integrity": "sha512-BEaNuDjpbbr9D4WhRMaJCrEUdDRkzffSCVkdP9IMWvHLtPR4sSm4vWHSysyspm9ozmHZ3sn/diFyWD5OE/WOPA==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-tokyo-night-day": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-day/-/codemirror-theme-tokyo-night-day-4.21.18.tgz",
-      "integrity": "sha512-GID7UabWPIgmOo5gLOzFkT/59T4RbIFMEDJ+pir+0zO91mzDIF8MhL781aD9Govr1lx7JYvO5YOFQvvy/jG7QA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-day/-/codemirror-theme-tokyo-night-day-4.21.19.tgz",
+      "integrity": "sha512-YBGKz+uXC7NlXdib/gBJbRuu/Kgvqt/HX2UKeNuCgPwcs0LYQ8ydMvU/seayuCP3SHKYXsqaPMdXmtYYxLSEBA==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-tokyo-night-storm": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-storm/-/codemirror-theme-tokyo-night-storm-4.21.18.tgz",
-      "integrity": "sha512-MUyVJLuF0JC01yZbTffNZPPRA6gY+c5P+/yEh1IJBHLtScLxOw+UgAdoGDFsYMyk9CJOhtUIhVyRCQkxstxKqA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-storm/-/codemirror-theme-tokyo-night-storm-4.21.19.tgz",
+      "integrity": "sha512-6dbM7WnB47mIKscFwK0yCQz3xloim/78+AxHB8NucVr6ooab0AqaBX0ug2Qec+OAf1q/zNf6EDtSYPFiDl8bPA==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-tomorrow-night-blue": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tomorrow-night-blue/-/codemirror-theme-tomorrow-night-blue-4.21.18.tgz",
-      "integrity": "sha512-+p2yEjshciCNYgAPQZEweaAQ5+tTEhQmbCTHZ5zKqB4y9P7xu3ut0I8iyTHxiAN1XUk/cn2BL3n8qvKyV9R2Nw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tomorrow-night-blue/-/codemirror-theme-tomorrow-night-blue-4.21.19.tgz",
+      "integrity": "sha512-SuzAZaNLmFznjMGncLhgd7fs0woww85e0q2hIvKq/osL7n8zCjOWfuNWwwN3D0+O5IptzC7mDgCfb0ofJxmN3Q==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-vscode": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-vscode/-/codemirror-theme-vscode-4.21.18.tgz",
-      "integrity": "sha512-ZyDBjYwD0kxS3NPBBHVjgq2AMntlUED4TkO6b4QaHAbcCY4G5seHwURxlpziptuVVLVBViuPpqNgL7OCJAMFZA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-vscode/-/codemirror-theme-vscode-4.21.19.tgz",
+      "integrity": "sha512-IpYMImRKbYutAOvPRNt1ep46EmCe7ZVMyMhzCuRAx6Jy2Dx9RRXjm5ppNqKV4IC7FTFYy9jzNXBNUOrN5Cb1tg==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-white": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-white/-/codemirror-theme-white-4.21.18.tgz",
-      "integrity": "sha512-6/dHxmh9WahFicGAzTPlIPLSvWPBjcUTnICeRyRX97Z4n3vUiKvu8VjtsbM/tvpJfYT/OFT5dDOBlOxzKXtfLA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-white/-/codemirror-theme-white-4.21.19.tgz",
+      "integrity": "sha512-547oKfS//bAJdjF1MSXpJSyodLEl9oQZ+FK8P0Ri6+pGbjLqLoBhw+cxGy0xhBVM6SkBaO5AaGolWrg8eZPcrQ==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-theme-xcode": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-xcode/-/codemirror-theme-xcode-4.21.18.tgz",
-      "integrity": "sha512-zG2mwTCThpUZC0jx/s2hjrfSwvsT/BvgxxsOWOhNAOYHQeNu/3EgdNb54atP/H8L+lodnz4TrAheqJJab7btdQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-xcode/-/codemirror-theme-xcode-4.21.19.tgz",
+      "integrity": "sha512-1p/JCxbbqPI2aBC2J6HCIjeUxtmH+CXTz/lmv33sXWBaoGWk2aQ7R6ueAzA4Mt0PKfOlQ5pAKMCWi7zCa449tg==",
       "dependencies": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@uiw/codemirror-themes": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.21.18.tgz",
-      "integrity": "sha512-9F/dm1jnRpp4pY+PCt+HCHz04SowFYjLiCGbqtx1x5f8+MBdKsT3qE2klLH8KHSkVplu2SaVUqCKj7WNuuvpcQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.21.19.tgz",
+      "integrity": "sha512-fA06v3jiPiCCXWQA6f3T7A4wzIYxLKxom5WgP0Qy5eP/hioTYaHAeS/4R/oomQ4AmtEoGa1L+mXEjBeCahhLsg==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -1360,45 +1360,45 @@
       }
     },
     "node_modules/@uiw/codemirror-themes-all": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes-all/-/codemirror-themes-all-4.21.18.tgz",
-      "integrity": "sha512-ngzOpos95O6OuA3e9cBI43Csk0LWiCj2VwidenUZTG+SolLEzchIvg7Rk4N4/S2coPMRd6d10FDOsgLBZ+LuzA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes-all/-/codemirror-themes-all-4.21.19.tgz",
+      "integrity": "sha512-NLMBjEtVneIz8SIsvhsw2e8u+sei0daYiy6T/2oc828NUrHNiHLaIDSCZdZ0UVVm3FafZM3WK4Tw4CQwcRX0eg==",
       "dependencies": {
-        "@uiw/codemirror-theme-abcdef": "4.21.18",
-        "@uiw/codemirror-theme-abyss": "4.21.18",
-        "@uiw/codemirror-theme-androidstudio": "4.21.18",
-        "@uiw/codemirror-theme-andromeda": "4.21.18",
-        "@uiw/codemirror-theme-atomone": "4.21.18",
-        "@uiw/codemirror-theme-aura": "4.21.18",
-        "@uiw/codemirror-theme-basic": "4.21.18",
-        "@uiw/codemirror-theme-bbedit": "4.21.18",
-        "@uiw/codemirror-theme-bespin": "4.21.18",
-        "@uiw/codemirror-theme-copilot": "4.21.18",
-        "@uiw/codemirror-theme-darcula": "4.21.18",
-        "@uiw/codemirror-theme-dracula": "4.21.18",
-        "@uiw/codemirror-theme-duotone": "4.21.18",
-        "@uiw/codemirror-theme-eclipse": "4.21.18",
-        "@uiw/codemirror-theme-github": "4.21.18",
-        "@uiw/codemirror-theme-gruvbox-dark": "4.21.18",
-        "@uiw/codemirror-theme-kimbie": "4.21.18",
-        "@uiw/codemirror-theme-material": "4.21.18",
-        "@uiw/codemirror-theme-monokai": "4.21.18",
-        "@uiw/codemirror-theme-monokai-dimmed": "4.21.18",
-        "@uiw/codemirror-theme-noctis-lilac": "4.21.18",
-        "@uiw/codemirror-theme-nord": "4.21.18",
-        "@uiw/codemirror-theme-okaidia": "4.21.18",
-        "@uiw/codemirror-theme-quietlight": "4.21.18",
-        "@uiw/codemirror-theme-red": "4.21.18",
-        "@uiw/codemirror-theme-solarized": "4.21.18",
-        "@uiw/codemirror-theme-sublime": "4.21.18",
-        "@uiw/codemirror-theme-tokyo-night": "4.21.18",
-        "@uiw/codemirror-theme-tokyo-night-day": "4.21.18",
-        "@uiw/codemirror-theme-tokyo-night-storm": "4.21.18",
-        "@uiw/codemirror-theme-tomorrow-night-blue": "4.21.18",
-        "@uiw/codemirror-theme-vscode": "4.21.18",
-        "@uiw/codemirror-theme-white": "4.21.18",
-        "@uiw/codemirror-theme-xcode": "4.21.18",
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-theme-abcdef": "4.21.19",
+        "@uiw/codemirror-theme-abyss": "4.21.19",
+        "@uiw/codemirror-theme-androidstudio": "4.21.19",
+        "@uiw/codemirror-theme-andromeda": "4.21.19",
+        "@uiw/codemirror-theme-atomone": "4.21.19",
+        "@uiw/codemirror-theme-aura": "4.21.19",
+        "@uiw/codemirror-theme-basic": "4.21.19",
+        "@uiw/codemirror-theme-bbedit": "4.21.19",
+        "@uiw/codemirror-theme-bespin": "4.21.19",
+        "@uiw/codemirror-theme-copilot": "4.21.19",
+        "@uiw/codemirror-theme-darcula": "4.21.19",
+        "@uiw/codemirror-theme-dracula": "4.21.19",
+        "@uiw/codemirror-theme-duotone": "4.21.19",
+        "@uiw/codemirror-theme-eclipse": "4.21.19",
+        "@uiw/codemirror-theme-github": "4.21.19",
+        "@uiw/codemirror-theme-gruvbox-dark": "4.21.19",
+        "@uiw/codemirror-theme-kimbie": "4.21.19",
+        "@uiw/codemirror-theme-material": "4.21.19",
+        "@uiw/codemirror-theme-monokai": "4.21.19",
+        "@uiw/codemirror-theme-monokai-dimmed": "4.21.19",
+        "@uiw/codemirror-theme-noctis-lilac": "4.21.19",
+        "@uiw/codemirror-theme-nord": "4.21.19",
+        "@uiw/codemirror-theme-okaidia": "4.21.19",
+        "@uiw/codemirror-theme-quietlight": "4.21.19",
+        "@uiw/codemirror-theme-red": "4.21.19",
+        "@uiw/codemirror-theme-solarized": "4.21.19",
+        "@uiw/codemirror-theme-sublime": "4.21.19",
+        "@uiw/codemirror-theme-tokyo-night": "4.21.19",
+        "@uiw/codemirror-theme-tokyo-night-day": "4.21.19",
+        "@uiw/codemirror-theme-tokyo-night-storm": "4.21.19",
+        "@uiw/codemirror-theme-tomorrow-night-blue": "4.21.19",
+        "@uiw/codemirror-theme-vscode": "4.21.19",
+        "@uiw/codemirror-theme-white": "4.21.19",
+        "@uiw/codemirror-theme-xcode": "4.21.19",
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1421,26 +1421,26 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.5.tgz",
-      "integrity": "sha512-/3RBIV9XEH+nRpRMqDJBufKIOQaYUH2X6bt0rKSCW0MfKhXFLYsR5ivHifeajRSTsln0FwJbitxLKHSQz/Xwkw==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz",
+      "integrity": "sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "0.34.5",
-        "@vitest/utils": "0.34.5",
-        "chai": "^4.3.7"
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
+        "chai": "^4.3.10"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.5.tgz",
-      "integrity": "sha512-RDEE3ViVvl7jFSCbnBRyYuu23XxmvRTSZWW6W4M7eC5dOsK75d5LIf6uhE5Fqf809DQ1+9ICZZNxhIolWHU4og==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.6.tgz",
+      "integrity": "sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "0.34.5",
+        "@vitest/utils": "0.34.6",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.1"
       },
@@ -1449,9 +1449,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.5.tgz",
-      "integrity": "sha512-+ikwSbhu6z2yOdtKmk/aeoDZ9QPm2g/ZO5rXT58RR9Vmu/kB2MamyDSx77dctqdZfP3Diqv4mbc/yw2kPT8rmA==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.6.tgz",
+      "integrity": "sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.1",
@@ -1463,9 +1463,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.5.tgz",
-      "integrity": "sha512-epsicsfhvBjRjCMOC/3k00mP/TBGQy8/P0DxOFiWyLt55gnZ99dqCfCiAsKO17BWVjn4eZRIjKvcqNmSz8gvmg==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.6.tgz",
+      "integrity": "sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.1.1"
@@ -1475,9 +1475,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.5.tgz",
-      "integrity": "sha512-ur6CmmYQoeHMwmGb0v+qwkwN3yopZuZyf4xt1DBBSGBed8Hf9Gmbm/5dEWqgpLPdRx6Av6jcWXrjcKfkTzg/pw==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
+      "integrity": "sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.4.3",
@@ -1810,18 +1810,18 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.9.tgz",
-      "integrity": "sha512-tH8vhfA1CfuYMkALXj+wmZcqiwqOfshU9Gry+NYiiLqIddrobkBhALv6XD4yDz68qapphYI4vSaqhqAdThCAAA==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
-        "deep-eql": "^4.1.2",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
         "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
+        "type-detect": "^4.0.8"
       },
       "engines": {
         "node": ">=4"
@@ -2498,6 +2498,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3071,9 +3085,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.4.tgz",
+      "integrity": "sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -3765,9 +3779,9 @@
       }
     },
     "node_modules/react-select": {
-      "version": "5.7.5",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.5.tgz",
-      "integrity": "sha512-jgYZa2xgKP0DVn5GZk7tZwbRx7kaVz1VqU41S8z1KWmshRDhlrpKS0w80aS1RaK5bVIXpttgSou7XCjWw1ncKA==",
+      "version": "5.7.7",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.7.tgz",
+      "integrity": "sha512-HhashZZJDRlfF/AKj0a0Lnfs3sRdw/46VJIRd8IbB9/Ovr74+ZIwkAdSBjSPXsFMG+u72c5xShqwLSKIJllzqw==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -4009,9 +4023,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.68.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.68.0.tgz",
-      "integrity": "sha512-Lmj9lM/fef0nQswm1J2HJcEsBUba4wgNx2fea6yJHODREoMFnwRpZydBnX/RjyXw2REIwdkbqE4hrTo4qfDBUA==",
+      "version": "1.69.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.2.tgz",
+      "integrity": "sha512-48lDtG/9OuSQZ9oNmJMUXI2QdCakAWrAGjpX/Fy6j4Og8dEAyE598x5GqCqnHkwV7+I5w8DJpqjm581q5HNh3w==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -4103,9 +4117,9 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sharedb": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-4.0.1.tgz",
-      "integrity": "sha512-lC+BetdEIpfinqvTvpBunY8aZWVOKxKt1Ki2peo6tmty2T9idOm/vwcgD/2W6l6ERzPhPqhxrPvD59uy/ugNtw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-4.1.0.tgz",
+      "integrity": "sha512-yCKgQ3yNutsX3JaiD40ZDgXzmM2estYizzp+hnw53PDoauJw7lF+LAWefA4FK5PvLRkVt5Erp9+z5IW4k7y6dg==",
       "dependencies": {
         "arraydiff": "^0.1.3",
         "async": "^3.2.4",
@@ -4270,9 +4284,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
-      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+      "integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -4357,9 +4371,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.0.tgz",
-      "integrity": "sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.1.tgz",
+      "integrity": "sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==",
       "dev": true
     },
     "node_modules/uncontrollable": {
@@ -4465,9 +4479,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
+      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -4520,9 +4534,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.5.tgz",
-      "integrity": "sha512-RNZ+DwbCvDoI5CbCSQSyRyzDTfFvFauvMs6Yq4ObJROKlIKuat1KgSX/Ako5rlDMfVCyMcpMRMTkJBxd6z8YRA==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz",
+      "integrity": "sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -4543,23 +4557,23 @@
       }
     },
     "node_modules/vitest": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.5.tgz",
-      "integrity": "sha512-CPI68mmnr2DThSB3frSuE5RLm9wo5wU4fbDrDwWQQB1CWgq9jQVoQwnQSzYAjdoBOPoH2UtXpOgHVge/uScfZg==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.6.tgz",
+      "integrity": "sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.34.5",
-        "@vitest/runner": "0.34.5",
-        "@vitest/snapshot": "0.34.5",
-        "@vitest/spy": "0.34.5",
-        "@vitest/utils": "0.34.5",
+        "@vitest/expect": "0.34.6",
+        "@vitest/runner": "0.34.6",
+        "@vitest/snapshot": "0.34.6",
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
         "acorn": "^8.9.0",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
-        "chai": "^4.3.7",
+        "chai": "^4.3.10",
         "debug": "^4.3.4",
         "local-pkg": "^0.4.3",
         "magic-string": "^0.30.1",
@@ -4570,7 +4584,7 @@
         "tinybench": "^2.5.0",
         "tinypool": "^0.7.0",
         "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
-        "vite-node": "0.34.5",
+        "vite-node": "0.34.6",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -5048,9 +5062,9 @@
       }
     },
     "@codemirror/lang-markdown": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.2.1.tgz",
-      "integrity": "sha512-Tpk1+CllQ/KU27AYixsxvtqqQS2xYfLEUiBEyyzO+Y9/0LfI2oB1qM2cMhy0D7oRnG0ZSAy9qcYniZc9VtlIxg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.2.2.tgz",
+      "integrity": "sha512-wmwM9Y5n/e4ndU51KcYDaQnb9goYdhXjU71dDW9goOc1VUTIPph6WKAPdJ6BzC0ZFy+UTsDwTXGWSP370RH69Q==",
       "requires": {
         "@codemirror/autocomplete": "^6.7.1",
         "@codemirror/lang-html": "^6.0.0",
@@ -5535,9 +5549,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
-      "version": "18.2.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.23.tgz",
-      "integrity": "sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==",
+      "version": "18.2.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.28.tgz",
+      "integrity": "sha512-ad4aa/RaaJS3hyGz0BGegdnSRXQBkd1CCYDCdNjBPg90UUpLgo+WlJqb9fMYUxtehmzF3PJaTWqRZjko6BRzBg==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5545,9 +5559,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.2.8",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.8.tgz",
-      "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
+      "version": "18.2.13",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.13.tgz",
+      "integrity": "sha512-eJIUv7rPP+EC45uNYp/ThhSpE16k22VJUknt5OLoH9tbXoi8bMhwLf5xRuWMywamNbWzhrSmU7IBJfPup1+3fw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -5589,281 +5603,281 @@
       }
     },
     "@uiw/codemirror-theme-abcdef": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abcdef/-/codemirror-theme-abcdef-4.21.18.tgz",
-      "integrity": "sha512-jobuck5/PfoZtHUwHc62jHMGLHVj6bS6HixOTKAg3N85Q0Fl9+E/rNTZ6hAeq6jFPBEMSxVoj2yz75NDxk+Qpw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abcdef/-/codemirror-theme-abcdef-4.21.19.tgz",
+      "integrity": "sha512-GB+aR5zgTkEDir8AWTCct4h5MdDyWCLtcGm74u6mli65qQWq7ng1sdcWzkFw7/NDXUi0tPwDZ8ZArIzCmU7olA==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-abyss": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abyss/-/codemirror-theme-abyss-4.21.18.tgz",
-      "integrity": "sha512-/7/GKGn5H25FE+dMYM49FkCoKhU2mc625KAl1QKoxcuN6pBhnDtfaSDEb6tnCqaPnkjCoJ2sQztifTJBrmuYyQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-abyss/-/codemirror-theme-abyss-4.21.19.tgz",
+      "integrity": "sha512-q7ttP5rNd9nJ541SWs6zc3BRw9EPCS29KPvBCvYwKd3rqyq9HLtpZf2r2hgw2eQSWbUFp54hH2UYrhP8jSIUOg==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-androidstudio": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-androidstudio/-/codemirror-theme-androidstudio-4.21.18.tgz",
-      "integrity": "sha512-+MUBh1wRmdN7P0flglBoZ6wxZld3u8rqovlF7y7EYhde7KOdmaVvM55QkYD16FEjNisCTTZ3z0A7tk7OzP1jaw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-androidstudio/-/codemirror-theme-androidstudio-4.21.19.tgz",
+      "integrity": "sha512-Pk3c8j5+IJ1E6iaUNiI2YkAGOXo7pGiqtJdiPQIfsbGQ/kL4RdjPfbuuevvC5bLtE6zOyjll4plOajL4qMPvzg==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-andromeda": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-andromeda/-/codemirror-theme-andromeda-4.21.18.tgz",
-      "integrity": "sha512-GzJ40zeobFxyu4kyHB2/7T/s8mQ3j7YxMTpEY1t8HzPTTeaCn0/9PmLZ4IBHY4/hFVWCENZkQ74SAcJAGo9g0w==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-andromeda/-/codemirror-theme-andromeda-4.21.19.tgz",
+      "integrity": "sha512-X+wAfkULUCuEUBEe9FFYF/aK0QOse7YEDXpoUzvsBoijlvp2HGTtLYlCul2h5YQ5WbEQGiSB8EVcaqcWoFLWzQ==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-atomone": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-atomone/-/codemirror-theme-atomone-4.21.18.tgz",
-      "integrity": "sha512-NPYlLkvs10b/+WubwPrwwPgzNdDgrCLC/mDlW4f/DKSSefdteUb8ReA6DUUCJCJiVoJPDjMwsqtCFUVoGU7JkA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-atomone/-/codemirror-theme-atomone-4.21.19.tgz",
+      "integrity": "sha512-aY302zmP/hro47UammNIZj9DLZBuUHzVgOLqaTUAiUzqvQ721ktL8qN4USRO3H1Bkn1W/+UuKFQTMyliFDkBKQ==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-aura": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-aura/-/codemirror-theme-aura-4.21.18.tgz",
-      "integrity": "sha512-2fXTT2t7K9Ri2M5Fek8XTOqkukAP50ocjKQnNjvmrjJx2yC07/Li58eeVHAX3xeo7WcaqdlEAftGzFYxlI5HaQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-aura/-/codemirror-theme-aura-4.21.19.tgz",
+      "integrity": "sha512-n+sZM3VDjGz2quovwO44Et21kQRJ5Ow4ZutZCimaIH6Oe7+++yNgqFXMqYs3M983CiIJX6r7ZKuawHW0XlV7Tw==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-basic": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-basic/-/codemirror-theme-basic-4.21.18.tgz",
-      "integrity": "sha512-4aW0i07AYQRNFr978HOyLMTHsOeUbj1OQlDKhL6o8LXXn7I3qAD9sS/hYJIdeiQVaDCI5s+JZgzavxbtvI+exA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-basic/-/codemirror-theme-basic-4.21.19.tgz",
+      "integrity": "sha512-w+UxYdZql48iFwJRIuaG6xPBKJlmUf+I01Fe0QUC1TmeLr/PXqwb2NAuknZxi4S7excRc6Zg2uFoLqpzZ0ADxQ==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-bbedit": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bbedit/-/codemirror-theme-bbedit-4.21.18.tgz",
-      "integrity": "sha512-SACfPbC+WEk7vrvY6sUnR3xVSjXvHjZjb3zi0XY/weRVUMMG4AnIkm0SHEtGct3VobjeuUlSisRg+PZVTDZ6jg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bbedit/-/codemirror-theme-bbedit-4.21.19.tgz",
+      "integrity": "sha512-Ps2qS4+FQB0tl/wUxzHBPIR9YBF7IzIDXjwxN0z0ieORkzDlnbzwqBHKNWWEAggD92DW3ZP9kdNitck7keMCpg==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-bespin": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bespin/-/codemirror-theme-bespin-4.21.18.tgz",
-      "integrity": "sha512-SJKOMaGZzO+mo3IUmDK0CV6pHKAxYFIASHYdcp70xe7/UY0D+NwI5+KQYNk9iEnu5Sttswa//y6ZHHNJ4uYTQw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-bespin/-/codemirror-theme-bespin-4.21.19.tgz",
+      "integrity": "sha512-4oeQ21+/WD2pKvxfv2Nl4UpDyglhLzLivIj8oRFOissgGsItOH6Goq/13ChjcQhzc42a5IDKf+HXpkdaXS+18w==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-copilot": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-copilot/-/codemirror-theme-copilot-4.21.18.tgz",
-      "integrity": "sha512-Trr3JYDbw1JZlCglIQH51ct6+8tz2cj3YaCmC5Xat8sRfV+CnyhlE0I3biehUxSPcfrcwxEzWk7P3sJO3duF8w==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-copilot/-/codemirror-theme-copilot-4.21.19.tgz",
+      "integrity": "sha512-C/m4U/PiKHn0GyhNeWWcX4zyMluw5MJQOpUGoUuukbEwNE8u95K3WthrBEQzEV6FcJjLt+WpJbXcdTCZ0ftaHg==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-darcula": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-darcula/-/codemirror-theme-darcula-4.21.18.tgz",
-      "integrity": "sha512-nOY7o3X2PbwHpuD3AWU7JhGiGiGD1cwEIdmdqjdAOliti8bTMdSpYhV41VrwTTTJOQLRZlYeQeMAZh43AkxFwg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-darcula/-/codemirror-theme-darcula-4.21.19.tgz",
+      "integrity": "sha512-TLosR1ZLM6CQb5hENzwiTwHdSHGOU67QhBGZC9+UuKK8PEit2wBrz+xVIBJ5glpsdXRYyVZQixtJFUPPxSH6fw==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-dracula": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-dracula/-/codemirror-theme-dracula-4.21.18.tgz",
-      "integrity": "sha512-5kuf8tlZ8Be/jv/5nsxKNb6e32/UgIii7ws/TNXBv5DkXpsqafxfnEL43HOjTh71wQJOYpnBLWVTZjV0GRGe0A==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-dracula/-/codemirror-theme-dracula-4.21.19.tgz",
+      "integrity": "sha512-/OqprQhShd3l/c5hDAtmnocOuMWiuy6nxn42isllyF7AGcThHGsXlYpHMpVaVLONsL8lBj2CnUoiDXgy35pIgQ==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-duotone": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-duotone/-/codemirror-theme-duotone-4.21.18.tgz",
-      "integrity": "sha512-e3q2gP6HmwO4HqCvr0D1iciWd/aAfkMQVTkN4U9JdrMkQGR7OKr822Y3IVbPtFx6QdftY/MKv8D1OUfxqz/YQA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-duotone/-/codemirror-theme-duotone-4.21.19.tgz",
+      "integrity": "sha512-T+Kuz9TJyI3MbqHW9n58FVCznEHIgKIrJlZh+ah6nNsGNUVOI4xdn6wLAauEyDD4uTL7ekI/Q/yI4YyebGhXmQ==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-eclipse": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-eclipse/-/codemirror-theme-eclipse-4.21.18.tgz",
-      "integrity": "sha512-8rNtN+peNDq8Wq3FpBfxLHs4qclQvY29xZuMw9C879prkNFqRHyqQ9kHMQW4DryanWZCi6BpKQRUE0TZUnC7lQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-eclipse/-/codemirror-theme-eclipse-4.21.19.tgz",
+      "integrity": "sha512-YATAOURKG/t2ZPbkkTBBjiJVuA3z/kc5VBpvVopp+BLcWjUyjohLFRAzxuxD6kS3PYE6h9oVEGHBXejnpXTDQg==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-github": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-github/-/codemirror-theme-github-4.21.18.tgz",
-      "integrity": "sha512-RviQ3WaG96DTaz2WP0vi3IGPCeaxRflglhv3hwYXrG/u5vRIbddfDB5R+A+Sr5HCKRGdPMpSo5xfKjwdI05LzQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-github/-/codemirror-theme-github-4.21.19.tgz",
+      "integrity": "sha512-VgtASDyTHH7IoVb9gI6AFyclwnQgCCWIEFm8v/QhENqwumpU2ar5P10usT4agk5WOWiy1kM2YS/MBCnfe0wutw==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-gruvbox-dark": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-gruvbox-dark/-/codemirror-theme-gruvbox-dark-4.21.18.tgz",
-      "integrity": "sha512-TIXi/lkM6KzBWgLFc6Pz8iXwvyDZr2K1tuqygZYUJjWCdeKsl4udrvm0mqmJLEotqyz17qJiDIc7vodu3YGjSw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-gruvbox-dark/-/codemirror-theme-gruvbox-dark-4.21.19.tgz",
+      "integrity": "sha512-a4GkHvPvoaFSyQST7wcso2ARjVp9+1pvB5hDybizqSFftH1t6V6Fw/ssw5Ne4TqfFuyasEmCPns5OFWtqNUFPw==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-kimbie": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-kimbie/-/codemirror-theme-kimbie-4.21.18.tgz",
-      "integrity": "sha512-VKSjEdsTlZcVNtG46eZ9gmNhN/PXPwzeA87ZntJPx3CCWRbkp90Pg/Sgcui19ZFlq5kC6f7kqo/mjv+JOGR0sQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-kimbie/-/codemirror-theme-kimbie-4.21.19.tgz",
+      "integrity": "sha512-xd4C8giaF2JjCg8Ob/GaEgsR8Wfz/km48fe+/B7QA2ByB496KP9R4eg2YRz5Qu05tGvVuuTrZD1Pj1rxSsD2dw==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-material": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.21.18.tgz",
-      "integrity": "sha512-a/EZ3ysKaeY9pmcr45eemnqLTcxC5ca67GiM4S+ZSIA4kG+AwwqdrHwtoajCfj4/RQ562b7GrxuXaJgtqPrz0g==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-material/-/codemirror-theme-material-4.21.19.tgz",
+      "integrity": "sha512-xS+hyth2Zl4NEKPP3H5JkANj5urCsMF/RrjsowWyxQneOU023rF96OwY+kuZWWLnmwJj4KYBrp7fpk5x5jLgmQ==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-monokai": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai/-/codemirror-theme-monokai-4.21.18.tgz",
-      "integrity": "sha512-uZDQQBLgbYZtqvQDEtlFZyuUuB8rqZrGJIx0P47vTTYy5HnU9FNqnuP0K0IhBm9oEyr/Ts1fHJ6IoovrtK5bJA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai/-/codemirror-theme-monokai-4.21.19.tgz",
+      "integrity": "sha512-PaRM0kks+LKn1uf0l33Z+LF31lvl8S+3vVPy26F9NZwn/ZOhE7UPzkmJ5Vm9KO5ueMPV1Dv2+j4DZTQUiz456Q==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-monokai-dimmed": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai-dimmed/-/codemirror-theme-monokai-dimmed-4.21.18.tgz",
-      "integrity": "sha512-IkJNaIAcEolbnv2QZq2HhHBSDjAUJZz0Aq3Gybp2ifCM1IKkcmGlgG8o7JVpKfn1crq50b1xKaiy4ZRZuOPjhg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai-dimmed/-/codemirror-theme-monokai-dimmed-4.21.19.tgz",
+      "integrity": "sha512-FkQQjZyWGxHeQ0cTRNSV/ezUHgd9ZG4ez6rV1gdJRAxPG4oY/qPOlwyYxWOa/MTI5cOwul5GgYVEmu962zE8Bg==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-noctis-lilac": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-noctis-lilac/-/codemirror-theme-noctis-lilac-4.21.18.tgz",
-      "integrity": "sha512-X2Gxw09qtji/b7e02VX1nTgl5a5XvXwAqkEX5VGmPpJLnnseoe5rHl8/UnK+viVbJ2iwFEobg5RBGiX0ZTmVSg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-noctis-lilac/-/codemirror-theme-noctis-lilac-4.21.19.tgz",
+      "integrity": "sha512-04CcGn4rR71Mt8h6cpLFDDYbgodQij2/uKZ1NxbO1XfBHIeBspn50omxGlPLAKIVv0pKKjespwQhGbI5NUKTZQ==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-nord": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-nord/-/codemirror-theme-nord-4.21.18.tgz",
-      "integrity": "sha512-aYaCQGq/4/gbxRAXQ8L8Wv9qZnRUHzQDyN0Zbc8VVfWfp2NW0CxEw9Do+EriRaVFsBDTBarEiBpjOR7lQkoKUw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-nord/-/codemirror-theme-nord-4.21.19.tgz",
+      "integrity": "sha512-7dJVo7xgopv3KoqdkurxTf1tUX7eVPX12OQNdxE3hl6d+l3taXn2Hjc/4zuLTJ4gaNAe34187GuPxpVHUjbiDA==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-okaidia": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-okaidia/-/codemirror-theme-okaidia-4.21.18.tgz",
-      "integrity": "sha512-kXrvbhupmgd2e4vAJNDLvGEpqZ01NHqJtlVWAlDUUZ8EvezbaPhPvl/7NWXMxYlcHndxPwi4pMFJqHmmEbyjZg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-okaidia/-/codemirror-theme-okaidia-4.21.19.tgz",
+      "integrity": "sha512-uUVG26TVTsVl/nv8MJjpCEpu/5uVMzuG6IyxzUC30+IkQG4V/MTW/AaWsng5pCqjroo1zMvMud/PCSfcSAI2gA==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-quietlight": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-quietlight/-/codemirror-theme-quietlight-4.21.18.tgz",
-      "integrity": "sha512-1aYRWlLJYsfY57Ht7iPEbcrd/h/mh5hIA1YfYZR0n31v5eQOr6i0iNoIcfMAzOT229DDPMeTXC4qPTWlFAt/JA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-quietlight/-/codemirror-theme-quietlight-4.21.19.tgz",
+      "integrity": "sha512-WRbXQRLKPR5qre4yj4MOunBZ1ryRQrvMR2fzwewDTVaNvuq/GDevMRUuwanlZQC3IP1xbOgE99jQH2vCY6t8Ew==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-red": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-red/-/codemirror-theme-red-4.21.18.tgz",
-      "integrity": "sha512-+olzy2PjhEA6i2Ye5CcSjfESzgWuKINa82AZagZ9/p4d427EYTpmRf+BCspcehbI05E9mqyDsUBulFz8yKdwnQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-red/-/codemirror-theme-red-4.21.19.tgz",
+      "integrity": "sha512-/CjajNL4XXusT/9+nuqQjFkx1QMfejdapXCo6+s20xJNfx2OAlTpLtVs08+5a/FJ2HEVbj/ckyjOfn2qbsW8+Q==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-solarized": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-solarized/-/codemirror-theme-solarized-4.21.18.tgz",
-      "integrity": "sha512-igQ2vHPoE8GpeSsU6ZJx2+ZSYG00pXaAf2R/bgK5B1PacJOyJQu8sP83YfwUJRUIm50baxzOvAiwZmoKvLpPSQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-solarized/-/codemirror-theme-solarized-4.21.19.tgz",
+      "integrity": "sha512-m4RMdV3HWDIit84/YtZp1Ua6d1FGD1iN3HKrM0V3FF1SC6o9ZPpIblK05/sl+Rfdv80RuP7as8NGb3fC945kmw==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-sublime": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-sublime/-/codemirror-theme-sublime-4.21.18.tgz",
-      "integrity": "sha512-/zaPbGpk1bXi/144jziLDOIrrgl14WxQYC7G5Yf6yYeWyz1JbbJgyQTaJ+xTNF9FQXL4ft6/oMteWfw+ZzBYjg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-sublime/-/codemirror-theme-sublime-4.21.19.tgz",
+      "integrity": "sha512-UxnLsCoc2mVAfI7AOrgchvbWGcfw3uVO5Ng7MShucbY/3UtMKY6gBJM2CD2w27vRIxV9KWQNacTe3dkuDaIASA==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-tokyo-night": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night/-/codemirror-theme-tokyo-night-4.21.18.tgz",
-      "integrity": "sha512-tXiFjR+J6jxH29PwzFSLCeWnEq1sOSmXWt7umoFu+9q41aZYsQox7kMSCghmy2YHX/IWB16VYDZJzKw1Qicjpg==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night/-/codemirror-theme-tokyo-night-4.21.19.tgz",
+      "integrity": "sha512-BEaNuDjpbbr9D4WhRMaJCrEUdDRkzffSCVkdP9IMWvHLtPR4sSm4vWHSysyspm9ozmHZ3sn/diFyWD5OE/WOPA==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-tokyo-night-day": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-day/-/codemirror-theme-tokyo-night-day-4.21.18.tgz",
-      "integrity": "sha512-GID7UabWPIgmOo5gLOzFkT/59T4RbIFMEDJ+pir+0zO91mzDIF8MhL781aD9Govr1lx7JYvO5YOFQvvy/jG7QA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-day/-/codemirror-theme-tokyo-night-day-4.21.19.tgz",
+      "integrity": "sha512-YBGKz+uXC7NlXdib/gBJbRuu/Kgvqt/HX2UKeNuCgPwcs0LYQ8ydMvU/seayuCP3SHKYXsqaPMdXmtYYxLSEBA==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-tokyo-night-storm": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-storm/-/codemirror-theme-tokyo-night-storm-4.21.18.tgz",
-      "integrity": "sha512-MUyVJLuF0JC01yZbTffNZPPRA6gY+c5P+/yEh1IJBHLtScLxOw+UgAdoGDFsYMyk9CJOhtUIhVyRCQkxstxKqA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tokyo-night-storm/-/codemirror-theme-tokyo-night-storm-4.21.19.tgz",
+      "integrity": "sha512-6dbM7WnB47mIKscFwK0yCQz3xloim/78+AxHB8NucVr6ooab0AqaBX0ug2Qec+OAf1q/zNf6EDtSYPFiDl8bPA==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-tomorrow-night-blue": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tomorrow-night-blue/-/codemirror-theme-tomorrow-night-blue-4.21.18.tgz",
-      "integrity": "sha512-+p2yEjshciCNYgAPQZEweaAQ5+tTEhQmbCTHZ5zKqB4y9P7xu3ut0I8iyTHxiAN1XUk/cn2BL3n8qvKyV9R2Nw==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-tomorrow-night-blue/-/codemirror-theme-tomorrow-night-blue-4.21.19.tgz",
+      "integrity": "sha512-SuzAZaNLmFznjMGncLhgd7fs0woww85e0q2hIvKq/osL7n8zCjOWfuNWwwN3D0+O5IptzC7mDgCfb0ofJxmN3Q==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-vscode": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-vscode/-/codemirror-theme-vscode-4.21.18.tgz",
-      "integrity": "sha512-ZyDBjYwD0kxS3NPBBHVjgq2AMntlUED4TkO6b4QaHAbcCY4G5seHwURxlpziptuVVLVBViuPpqNgL7OCJAMFZA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-vscode/-/codemirror-theme-vscode-4.21.19.tgz",
+      "integrity": "sha512-IpYMImRKbYutAOvPRNt1ep46EmCe7ZVMyMhzCuRAx6Jy2Dx9RRXjm5ppNqKV4IC7FTFYy9jzNXBNUOrN5Cb1tg==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-white": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-white/-/codemirror-theme-white-4.21.18.tgz",
-      "integrity": "sha512-6/dHxmh9WahFicGAzTPlIPLSvWPBjcUTnICeRyRX97Z4n3vUiKvu8VjtsbM/tvpJfYT/OFT5dDOBlOxzKXtfLA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-white/-/codemirror-theme-white-4.21.19.tgz",
+      "integrity": "sha512-547oKfS//bAJdjF1MSXpJSyodLEl9oQZ+FK8P0Ri6+pGbjLqLoBhw+cxGy0xhBVM6SkBaO5AaGolWrg8eZPcrQ==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-theme-xcode": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-xcode/-/codemirror-theme-xcode-4.21.18.tgz",
-      "integrity": "sha512-zG2mwTCThpUZC0jx/s2hjrfSwvsT/BvgxxsOWOhNAOYHQeNu/3EgdNb54atP/H8L+lodnz4TrAheqJJab7btdQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-xcode/-/codemirror-theme-xcode-4.21.19.tgz",
+      "integrity": "sha512-1p/JCxbbqPI2aBC2J6HCIjeUxtmH+CXTz/lmv33sXWBaoGWk2aQ7R6ueAzA4Mt0PKfOlQ5pAKMCWi7zCa449tg==",
       "requires": {
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@uiw/codemirror-themes": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.21.18.tgz",
-      "integrity": "sha512-9F/dm1jnRpp4pY+PCt+HCHz04SowFYjLiCGbqtx1x5f8+MBdKsT3qE2klLH8KHSkVplu2SaVUqCKj7WNuuvpcQ==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.21.19.tgz",
+      "integrity": "sha512-fA06v3jiPiCCXWQA6f3T7A4wzIYxLKxom5WgP0Qy5eP/hioTYaHAeS/4R/oomQ4AmtEoGa1L+mXEjBeCahhLsg==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -5871,45 +5885,45 @@
       }
     },
     "@uiw/codemirror-themes-all": {
-      "version": "4.21.18",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes-all/-/codemirror-themes-all-4.21.18.tgz",
-      "integrity": "sha512-ngzOpos95O6OuA3e9cBI43Csk0LWiCj2VwidenUZTG+SolLEzchIvg7Rk4N4/S2coPMRd6d10FDOsgLBZ+LuzA==",
+      "version": "4.21.19",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes-all/-/codemirror-themes-all-4.21.19.tgz",
+      "integrity": "sha512-NLMBjEtVneIz8SIsvhsw2e8u+sei0daYiy6T/2oc828NUrHNiHLaIDSCZdZ0UVVm3FafZM3WK4Tw4CQwcRX0eg==",
       "requires": {
-        "@uiw/codemirror-theme-abcdef": "4.21.18",
-        "@uiw/codemirror-theme-abyss": "4.21.18",
-        "@uiw/codemirror-theme-androidstudio": "4.21.18",
-        "@uiw/codemirror-theme-andromeda": "4.21.18",
-        "@uiw/codemirror-theme-atomone": "4.21.18",
-        "@uiw/codemirror-theme-aura": "4.21.18",
-        "@uiw/codemirror-theme-basic": "4.21.18",
-        "@uiw/codemirror-theme-bbedit": "4.21.18",
-        "@uiw/codemirror-theme-bespin": "4.21.18",
-        "@uiw/codemirror-theme-copilot": "4.21.18",
-        "@uiw/codemirror-theme-darcula": "4.21.18",
-        "@uiw/codemirror-theme-dracula": "4.21.18",
-        "@uiw/codemirror-theme-duotone": "4.21.18",
-        "@uiw/codemirror-theme-eclipse": "4.21.18",
-        "@uiw/codemirror-theme-github": "4.21.18",
-        "@uiw/codemirror-theme-gruvbox-dark": "4.21.18",
-        "@uiw/codemirror-theme-kimbie": "4.21.18",
-        "@uiw/codemirror-theme-material": "4.21.18",
-        "@uiw/codemirror-theme-monokai": "4.21.18",
-        "@uiw/codemirror-theme-monokai-dimmed": "4.21.18",
-        "@uiw/codemirror-theme-noctis-lilac": "4.21.18",
-        "@uiw/codemirror-theme-nord": "4.21.18",
-        "@uiw/codemirror-theme-okaidia": "4.21.18",
-        "@uiw/codemirror-theme-quietlight": "4.21.18",
-        "@uiw/codemirror-theme-red": "4.21.18",
-        "@uiw/codemirror-theme-solarized": "4.21.18",
-        "@uiw/codemirror-theme-sublime": "4.21.18",
-        "@uiw/codemirror-theme-tokyo-night": "4.21.18",
-        "@uiw/codemirror-theme-tokyo-night-day": "4.21.18",
-        "@uiw/codemirror-theme-tokyo-night-storm": "4.21.18",
-        "@uiw/codemirror-theme-tomorrow-night-blue": "4.21.18",
-        "@uiw/codemirror-theme-vscode": "4.21.18",
-        "@uiw/codemirror-theme-white": "4.21.18",
-        "@uiw/codemirror-theme-xcode": "4.21.18",
-        "@uiw/codemirror-themes": "4.21.18"
+        "@uiw/codemirror-theme-abcdef": "4.21.19",
+        "@uiw/codemirror-theme-abyss": "4.21.19",
+        "@uiw/codemirror-theme-androidstudio": "4.21.19",
+        "@uiw/codemirror-theme-andromeda": "4.21.19",
+        "@uiw/codemirror-theme-atomone": "4.21.19",
+        "@uiw/codemirror-theme-aura": "4.21.19",
+        "@uiw/codemirror-theme-basic": "4.21.19",
+        "@uiw/codemirror-theme-bbedit": "4.21.19",
+        "@uiw/codemirror-theme-bespin": "4.21.19",
+        "@uiw/codemirror-theme-copilot": "4.21.19",
+        "@uiw/codemirror-theme-darcula": "4.21.19",
+        "@uiw/codemirror-theme-dracula": "4.21.19",
+        "@uiw/codemirror-theme-duotone": "4.21.19",
+        "@uiw/codemirror-theme-eclipse": "4.21.19",
+        "@uiw/codemirror-theme-github": "4.21.19",
+        "@uiw/codemirror-theme-gruvbox-dark": "4.21.19",
+        "@uiw/codemirror-theme-kimbie": "4.21.19",
+        "@uiw/codemirror-theme-material": "4.21.19",
+        "@uiw/codemirror-theme-monokai": "4.21.19",
+        "@uiw/codemirror-theme-monokai-dimmed": "4.21.19",
+        "@uiw/codemirror-theme-noctis-lilac": "4.21.19",
+        "@uiw/codemirror-theme-nord": "4.21.19",
+        "@uiw/codemirror-theme-okaidia": "4.21.19",
+        "@uiw/codemirror-theme-quietlight": "4.21.19",
+        "@uiw/codemirror-theme-red": "4.21.19",
+        "@uiw/codemirror-theme-solarized": "4.21.19",
+        "@uiw/codemirror-theme-sublime": "4.21.19",
+        "@uiw/codemirror-theme-tokyo-night": "4.21.19",
+        "@uiw/codemirror-theme-tokyo-night-day": "4.21.19",
+        "@uiw/codemirror-theme-tokyo-night-storm": "4.21.19",
+        "@uiw/codemirror-theme-tomorrow-night-blue": "4.21.19",
+        "@uiw/codemirror-theme-vscode": "4.21.19",
+        "@uiw/codemirror-theme-white": "4.21.19",
+        "@uiw/codemirror-theme-xcode": "4.21.19",
+        "@uiw/codemirror-themes": "4.21.19"
       }
     },
     "@vitejs/plugin-react": {
@@ -5926,31 +5940,31 @@
       }
     },
     "@vitest/expect": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.5.tgz",
-      "integrity": "sha512-/3RBIV9XEH+nRpRMqDJBufKIOQaYUH2X6bt0rKSCW0MfKhXFLYsR5ivHifeajRSTsln0FwJbitxLKHSQz/Xwkw==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz",
+      "integrity": "sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==",
       "dev": true,
       "requires": {
-        "@vitest/spy": "0.34.5",
-        "@vitest/utils": "0.34.5",
-        "chai": "^4.3.7"
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
+        "chai": "^4.3.10"
       }
     },
     "@vitest/runner": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.5.tgz",
-      "integrity": "sha512-RDEE3ViVvl7jFSCbnBRyYuu23XxmvRTSZWW6W4M7eC5dOsK75d5LIf6uhE5Fqf809DQ1+9ICZZNxhIolWHU4og==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.6.tgz",
+      "integrity": "sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==",
       "dev": true,
       "requires": {
-        "@vitest/utils": "0.34.5",
+        "@vitest/utils": "0.34.6",
         "p-limit": "^4.0.0",
         "pathe": "^1.1.1"
       }
     },
     "@vitest/snapshot": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.5.tgz",
-      "integrity": "sha512-+ikwSbhu6z2yOdtKmk/aeoDZ9QPm2g/ZO5rXT58RR9Vmu/kB2MamyDSx77dctqdZfP3Diqv4mbc/yw2kPT8rmA==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.6.tgz",
+      "integrity": "sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==",
       "dev": true,
       "requires": {
         "magic-string": "^0.30.1",
@@ -5959,18 +5973,18 @@
       }
     },
     "@vitest/spy": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.5.tgz",
-      "integrity": "sha512-epsicsfhvBjRjCMOC/3k00mP/TBGQy8/P0DxOFiWyLt55gnZ99dqCfCiAsKO17BWVjn4eZRIjKvcqNmSz8gvmg==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.6.tgz",
+      "integrity": "sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==",
       "dev": true,
       "requires": {
         "tinyspy": "^2.1.1"
       }
     },
     "@vitest/utils": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.5.tgz",
-      "integrity": "sha512-ur6CmmYQoeHMwmGb0v+qwkwN3yopZuZyf4xt1DBBSGBed8Hf9Gmbm/5dEWqgpLPdRx6Av6jcWXrjcKfkTzg/pw==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
+      "integrity": "sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==",
       "dev": true,
       "requires": {
         "diff-sequences": "^29.4.3",
@@ -6196,18 +6210,18 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.9.tgz",
-      "integrity": "sha512-tH8vhfA1CfuYMkALXj+wmZcqiwqOfshU9Gry+NYiiLqIddrobkBhALv6XD4yDz68qapphYI4vSaqhqAdThCAAA==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
-        "deep-eql": "^4.1.2",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
         "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
+        "type-detect": "^4.0.8"
       }
     },
     "chalk": {
@@ -6722,6 +6736,13 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7126,9 +7147,9 @@
       }
     },
     "magic-string": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.4.tgz",
+      "integrity": "sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==",
       "dev": true,
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -7607,9 +7628,9 @@
       "dev": true
     },
     "react-select": {
-      "version": "5.7.5",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.5.tgz",
-      "integrity": "sha512-jgYZa2xgKP0DVn5GZk7tZwbRx7kaVz1VqU41S8z1KWmshRDhlrpKS0w80aS1RaK5bVIXpttgSou7XCjWw1ncKA==",
+      "version": "5.7.7",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.7.tgz",
+      "integrity": "sha512-HhashZZJDRlfF/AKj0a0Lnfs3sRdw/46VJIRd8IbB9/Ovr74+ZIwkAdSBjSPXsFMG+u72c5xShqwLSKIJllzqw==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -7767,9 +7788,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.68.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.68.0.tgz",
-      "integrity": "sha512-Lmj9lM/fef0nQswm1J2HJcEsBUba4wgNx2fea6yJHODREoMFnwRpZydBnX/RjyXw2REIwdkbqE4hrTo4qfDBUA==",
+      "version": "1.69.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.2.tgz",
+      "integrity": "sha512-48lDtG/9OuSQZ9oNmJMUXI2QdCakAWrAGjpX/Fy6j4Og8dEAyE598x5GqCqnHkwV7+I5w8DJpqjm581q5HNh3w==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -7850,9 +7871,9 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "sharedb": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-4.0.1.tgz",
-      "integrity": "sha512-lC+BetdEIpfinqvTvpBunY8aZWVOKxKt1Ki2peo6tmty2T9idOm/vwcgD/2W6l6ERzPhPqhxrPvD59uy/ugNtw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sharedb/-/sharedb-4.1.0.tgz",
+      "integrity": "sha512-yCKgQ3yNutsX3JaiD40ZDgXzmM2estYizzp+hnw53PDoauJw7lF+LAWefA4FK5PvLRkVt5Erp9+z5IW4k7y6dg==",
       "requires": {
         "arraydiff": "^0.1.3",
         "async": "^3.2.4",
@@ -7978,9 +7999,9 @@
       "dev": true
     },
     "tinyspy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
-      "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+      "integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
       "dev": true
     },
     "titleize": {
@@ -8034,9 +8055,9 @@
       "dev": true
     },
     "ufo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.0.tgz",
-      "integrity": "sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.1.tgz",
+      "integrity": "sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==",
       "dev": true
     },
     "uncontrollable": {
@@ -8097,9 +8118,9 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
+      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",
@@ -8109,9 +8130,9 @@
       }
     },
     "vite-node": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.5.tgz",
-      "integrity": "sha512-RNZ+DwbCvDoI5CbCSQSyRyzDTfFvFauvMs6Yq4ObJROKlIKuat1KgSX/Ako5rlDMfVCyMcpMRMTkJBxd6z8YRA==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz",
+      "integrity": "sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==",
       "dev": true,
       "requires": {
         "cac": "^6.7.14",
@@ -8123,23 +8144,23 @@
       }
     },
     "vitest": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.5.tgz",
-      "integrity": "sha512-CPI68mmnr2DThSB3frSuE5RLm9wo5wU4fbDrDwWQQB1CWgq9jQVoQwnQSzYAjdoBOPoH2UtXpOgHVge/uScfZg==",
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.6.tgz",
+      "integrity": "sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==",
       "dev": true,
       "requires": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",
         "@types/node": "*",
-        "@vitest/expect": "0.34.5",
-        "@vitest/runner": "0.34.5",
-        "@vitest/snapshot": "0.34.5",
-        "@vitest/spy": "0.34.5",
-        "@vitest/utils": "0.34.5",
+        "@vitest/expect": "0.34.6",
+        "@vitest/runner": "0.34.6",
+        "@vitest/snapshot": "0.34.6",
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
         "acorn": "^8.9.0",
         "acorn-walk": "^8.2.0",
         "cac": "^6.7.14",
-        "chai": "^4.3.7",
+        "chai": "^4.3.10",
         "debug": "^4.3.4",
         "local-pkg": "^0.4.3",
         "magic-string": "^0.30.1",
@@ -8150,7 +8171,7 @@
         "tinybench": "^2.5.0",
         "tinypool": "^0.7.0",
         "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
-        "vite-node": "0.34.5",
+        "vite-node": "0.34.6",
         "why-is-node-running": "^2.2.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
     "@codemirror/lang-css": "^6.2.1",
     "@codemirror/lang-html": "^6.4.6",
     "@codemirror/lang-javascript": "^6.2.1",
-    "@codemirror/lang-markdown": "^6.2.1",
+    "@codemirror/lang-markdown": "^6.2.2",
     "@codemirror/state": "^6.2.1",
     "@codemirror/theme-one-dark": "^6.1.2",
     "@replit/codemirror-interact": "^6.3.0",
     "@teamwork/websocket-json-stream": "^2.0.0",
-    "@uiw/codemirror-themes-all": "^4.21.18",
+    "@uiw/codemirror-themes-all": "^4.21.19",
     "codemirror": "^6.0.1",
     "codemirror-ot": "^4.1.0",
     "d3-array": "^3.2.4",
@@ -67,20 +67,19 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.9.0",
     "react-dom": "^18.2.0",
-    "react-select": "^5.7.5",
-    "sharedb": "^4.0.1",
+    "sharedb": "^4.1.0",
     "sharedb-client-browser": "^4.3.1",
     "ot-json1": "^1.0.2",
     "ws": "^8.14.2"
   },
   "devDependencies": {
-    "@types/react": "^18.2.23",
-    "@types/react-dom": "^18.2.8",
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.13",
     "@vitejs/plugin-react": "^4.1.0",
     "prettier": "^3.0.3",
-    "sass": "^1.68.0",
+    "sass": "^1.69.2",
     "typescript": "^5.2.2",
-    "vite": "^4.4.9",
-    "vitest": "^0.34.5"
+    "vite": "^4.4.11",
+    "vitest": "^0.34.6"
   }
 }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -228,36 +228,35 @@ function App() {
   );
 
   const deleteDirectory = useCallback(
-      (path: FileId) => {
-        submitOperation((document) => {
-          const updatedFiles = { ...document.files };
-          for (const key in updatedFiles) {
-            if (updatedFiles[key].name.includes(path)) {
-              closeTab(key);
-              delete updatedFiles[key];
-            }
+    (path: FileId) => {
+      submitOperation((document) => {
+        const updatedFiles = { ...document.files };
+        for (const key in updatedFiles) {
+          if (updatedFiles[key].name.includes(path)) {
+            closeTab(key);
+            delete updatedFiles[key];
           }
-          return { ...document, files: updatedFiles };
-        });
-      },
-      [submitOperation, closeTab],
+        }
+        return { ...document, files: updatedFiles };
+      });
+    },
+    [submitOperation, closeTab],
   );
 
   const handleDeleteClick = useCallback(
-      (key: string) => {
-        //Regex to identify if the key is a file path or a file id.
-        if (/^[0-9]*$/.test(key)) {
-          if (key.length == 8) {
-            deleteFile(key);
-          } else {
-            deleteDirectory(key);
-          }
-        }
-        else{
+    (key: string) => {
+      //Regex to identify if the key is a file path or a file id.
+      if (/^[0-9]*$/.test(key)) {
+        if (key.length == 8) {
+          deleteFile(key);
+        } else {
           deleteDirectory(key);
         }
-      },
-      [deleteFile, deleteDirectory],
+      } else {
+        deleteDirectory(key);
+      }
+    },
+    [deleteFile, deleteDirectory],
   );
 
   const handleSettingsClose = useCallback(() => {

--- a/src/client/CodeEditor/getOrCreateEditor.ts
+++ b/src/client/CodeEditor/getOrCreateEditor.ts
@@ -127,7 +127,7 @@ export const getOrCreateEditor = ({
       json1PresenceDisplay({ path: textPath, docPresence }),
     );
 
-    extensions.push(colorsInTextPlugin);
+  extensions.push(colorsInTextPlugin);
 
   // This is the "basic setup" for CodeMirror,
   // which actually adds a ton on functionality.

--- a/src/client/Settings.tsx
+++ b/src/client/Settings.tsx
@@ -1,18 +1,13 @@
 import { useCallback } from 'react';
 import { Button, Modal, Form } from './bootstrap';
-import Select from 'react-select';
-import {
-  ThemeLabel,
-  themeOptionsByLabel,
-  themes,
-} from './themes';
+import { ThemeLabel, themes } from './themes';
 
-const saveTimes = [
-  { value: 1, label: '1 second' },
-  { value: 5, label: '5 seconds' },
-  { value: 10, label: '10 seconds' },
-  { value: 30, label: '30 seconds' },
-];
+// const saveTimes = [
+//   { value: 1, label: '1 second' },
+//   { value: 5, label: '5 seconds' },
+//   { value: 10, label: '10 seconds' },
+//   { value: 30, label: '30 seconds' },
+// ];
 
 export const Settings = ({
   show,
@@ -25,23 +20,26 @@ export const Settings = ({
   setTheme: (theme: ThemeLabel) => void;
   theme: ThemeLabel;
 }) => {
-  const handleChange = useCallback((selectedOption) => {
-    setTheme(selectedOption.label);
+  const handleThemeChange = useCallback((event) => {
+    const selectedValue = event.target.value;
+    console.log(selectedValue);
+    setTheme(selectedValue);
   }, []);
 
-  const handleSaveTimeChange = useCallback(
-    (selectedOption) => {
-      const time = [{ value: selectedOption.value }];
-      fetch('/saveTime', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(time),
-      });
-    },
-    [],
-  );
+  // TODO https://github.com/vizhub-core/vzcode/issues/95
+  // const handleSaveTimeChange = useCallback(
+  //   (selectedOption) => {
+  //     const time = [{ value: selectedOption.value }];
+  //     fetch('/saveTime', {
+  //       method: 'POST',
+  //       headers: {
+  //         'Content-Type': 'application/json',
+  //       },
+  //       body: JSON.stringify(time),
+  //     });
+  //   },
+  //   [],
+  // );
 
   return show ? (
     <Modal
@@ -66,16 +64,26 @@ export const Settings = ({
         </Form.Group>
         <Form.Group className="mb-3" controlId="formFork">
           <Form.Label>Theme</Form.Label>
-          <Select
-            options={themes}
-            onChange={handleChange}
-            value={themeOptionsByLabel[theme]}
-          />
+
+          <select
+            className="form-select"
+            value={theme}
+            onChange={handleThemeChange}
+          >
+            {themes.map(({ label }) => (
+              <option key={label} value={label}>
+                {label}
+              </option>
+            ))}
+          </select>
+
           <Form.Text className="text-muted">
             Select a color theme for the editor
           </Form.Text>
         </Form.Group>
-        <Form.Group className="mb-3" controlId="formFork">
+        {/*
+          TODO https://github.com/vizhub-core/vzcode/issues/95
+          <Form.Group className="mb-3" controlId="formFork">
           <Form.Label>Auto-Save Time</Form.Label>
           <Select
             options={saveTimes}
@@ -84,7 +92,7 @@ export const Settings = ({
           <Form.Text className="text-muted">
             Select an auto save time
           </Form.Text>
-        </Form.Group>
+        </Form.Group> */}
       </Modal.Body>
       <Modal.Footer>
         <Button variant="primary" onClick={onClose}>

--- a/src/client/Sidebar/DirectoryListing.tsx
+++ b/src/client/Sidebar/DirectoryListing.tsx
@@ -33,10 +33,13 @@ export const DirectoryListing = ({
     toggleDirectory(path);
   }, [toggleDirectory]);
 
-  const handleDeleteClick = useCallback((event) => {
-    // https://github.com/vizhub-core/vzcode/issues/102
-    handleDeleteFileClick(path,event);
-  }, [handleDeleteFileClick,path]);
+  const handleDeleteClick = useCallback(
+    (event) => {
+      // https://github.com/vizhub-core/vzcode/issues/102
+      handleDeleteFileClick(path, event);
+    },
+    [handleDeleteFileClick, path],
+  );
 
   const handleRenameClick = useCallback(() => {
     // https://github.com/vizhub-core/vzcode/issues/103

--- a/src/client/Sidebar/FileListing.tsx
+++ b/src/client/Sidebar/FileListing.tsx
@@ -41,12 +41,12 @@ export const FileListing = ({
 
   return (
     <Item
-        name={name}
-        handleClick={handleClick}
-        handleDeleteClick={handleDeleteClick}
-        handleRenameClick={handleRenameClick}
+      name={name}
+      handleClick={handleClick}
+      handleDeleteClick={handleDeleteClick}
+      handleRenameClick={handleRenameClick}
       isDir={false}
-      name = {name}
+      name={name}
     >
       {name}
     </Item>


### PR DESCRIPTION
Removes `react-select` as a dependency, as it's a heavyweight package, and it's causing some downstream dependency hell issues.