### PR TITLE
Delete directory/files bug fixes

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -153,7 +153,7 @@ function App() {
   const [tabList, setTabList] = useState<Array<FileId>>([]);
 
   // Logic for opening and closing tabs.
-  const { closeTab, openTab } = useTabsState(
+  const { closeTab, openTab, multiCloseTab } = useTabsState(
     activeFileId,
     setActiveFileId,
     tabList,
@@ -217,30 +217,32 @@ function App() {
 
   const deleteFile = useCallback(
     (fileId: FileId) => {
-      closeTab(fileId);
       submitOperation((document) => {
         const updatedFiles = { ...document.files };
         delete updatedFiles[fileId];
         return { ...document, files: updatedFiles };
       });
+      closeTab(fileId);
     },
     [submitOperation, closeTab],
   );
 
   const deleteDirectory = useCallback(
     (path: FileId) => {
+      let tabsToDelete: Array<FileId> = [];
       submitOperation((document) => {
         const updatedFiles = { ...document.files };
         for (const key in updatedFiles) {
           if (updatedFiles[key].name.includes(path)) {
-            closeTab(key);
+            tabsToDelete.push(key);
             delete updatedFiles[key];
           }
         }
         return { ...document, files: updatedFiles };
       });
+      multiCloseTab(tabsToDelete);
     },
-    [submitOperation, closeTab],
+    [submitOperation, multiCloseTab],
   );
 
   const handleDeleteClick = useCallback(

--- a/src/client/Sidebar/Item.tsx
+++ b/src/client/Sidebar/Item.tsx
@@ -42,9 +42,13 @@ export const Item = ({
   const [showModal, setShowModal] = useState(false);
 
   // Function to open the delete file confirmation modal
-  const handleModalOpen = useCallback(() => {
-    setShowModal(true);
-  }, []);
+  const handleModalOpen = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      setShowModal(true);
+    },
+    [],
+  );
 
   // Function to close the modal
   const handleModalClose = useCallback(() => {
@@ -52,10 +56,14 @@ export const Item = ({
   }, []);
 
   // Function to handle confirmation on modal
-  const handleConfirmModal = useCallback(() => {
-    setShowModal(false);
-    handleDeleteClick();
-  }, [handleDeleteClick]);
+  const handleConfirmModal = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      setShowModal(false);
+      handleDeleteClick();
+    },
+    [handleDeleteClick],
+  );
 
   const handleMouseEnter = useCallback(() => {
     setIsHovered(true);
@@ -98,7 +106,8 @@ export const Item = ({
           <i
             className="bx bxs-edit utilities"
             style={{ color: '#abdafb' }}
-            onClick={() => {
+            onClick={(event: React.MouseEvent) => {
+              event.stopPropagation();
               setIsRenaming(!isRenaming);
               setRenameValue(isDir ? name : children);
             }}

--- a/src/client/useTabsState.ts
+++ b/src/client/useTabsState.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback} from 'react';
 import { FileId } from '../types';
 
 // Encapsulates the state and logic for managing the list of open tabs.
@@ -11,6 +11,7 @@ export const useTabsState = (
   // Called when a tab is closed.
   const closeTab = useCallback(
     (fileIdToRemove: FileId) => {
+      let newActiveFileId: FileId = activeFileId;
       const i = tabList.findIndex(
         (fileId) => fileId === fileIdToRemove,
       );
@@ -29,16 +30,52 @@ export const useTabsState = (
         if (activeFileId === fileIdToRemove) {
           // set the new active file to the next tab over,
           if (newTabList.length > 0) {
-            setActiveFileId(
-              i === 0 ? newTabList[i] : newTabList[i - 1],
-            );
+            newActiveFileId =
+              i === 0 ? newTabList[i] : newTabList[i - 1];
           } else {
             // or clear out the active file
             // if we've closed the last tab.
-            setActiveFileId(null);
+            newActiveFileId = null;
           }
         }
       }
+      setActiveFileId(newActiveFileId);
+    },
+    [tabList, activeFileId],
+  );
+
+  //When closing multiple tabs use this function over CloseTab()
+  const multiCloseTab = useCallback(
+    (idsToDelete: Array<FileId>) => {
+      let newTabList = [...tabList]; // Create a copy of the tabList array.
+      let newActiveFileId: FileId = activeFileId;
+      idsToDelete.forEach((id) => {
+        const i = newTabList.findIndex(
+          (fileId) => fileId === id,
+        );
+        if (i !== -1) {
+          // Remove the tab from the tab list.
+          newTabList = [
+            ...newTabList.slice(0, i),
+            ...newTabList.slice(i + 1),
+          ];
+
+          // If we are closing the active file,
+          if (newActiveFileId === id) {
+            // set the new active file to the next tab over,
+            if (newTabList.length > 0) {
+              newActiveFileId =
+                i === 0 ? newTabList[i] : newTabList[i - 1];
+            } else {
+              // or clear out the active file if we've closed the last tab.
+              newActiveFileId = null;
+            }
+          }
+        }
+      });
+      //Run setStates after doing multiple changes to the two variables. Will properly render tabList and activeFileID.
+      setActiveFileId(newActiveFileId);
+      setTabList(newTabList);
     },
     [tabList, activeFileId],
   );
@@ -54,5 +91,5 @@ export const useTabsState = (
     [tabList],
   );
 
-  return { tabList, closeTab, openTab };
+  return { tabList, closeTab, openTab, multiCloseTab };
 };


### PR DESCRIPTION
Closes #223 
Closes #215 

Decided to bundle the fix to both these bug fixes together since they relate to similar issues. However the solutions to the problems are not related.

The first solution for #223 is related to a pitfall of react's useState. useState as stated in the documentation "does not change the current state in already executing code".  So by calling closeTab multiple times like we used to, resulted in the tabList not being updated at all because of all the conflicting setTabList calls. To solve this issue I created a new method that takes in array of fileIds that we want to close and only uses one setTabList call.

While tackling this issue it made me realize an interesting drawback from using reacts useStates. #223 was difficult to debug and it took a lot of time to carefully track down why our setTabList was incorrectly working. @curran brought up a good point the other day where we could perform a code refractor and change most of or even all of our useStates into a reducer. It would make such cases easier to debug. However, the tradeoff is that useReducer can result in a more complicated code in relation to our useStates. I think this may be worth discussing if we continue to have issues with our useStates as we continue to expand the codebase. See: https://react.dev/learn/extracting-state-logic-into-a-reducer# for more details on reducers.

The solution to #215 interestingly is not related to dependencies, like I originally thought, but was actually an issue with the modal implementation. Previously we had it such that interacting with the sidebar in anyway resulted in the item opening. This meant when you went to delete a file by clicking the trash button resulted in the modal and the file opening. Interestingly if you confirmed the modal/clicked yes this resulted in another event triggering the open of the object which in turn changed the activeFileId again after we already close it in deleteFile(). To solve this it just took a event.stopPropagation() in handleConfirmModal.

While I was solving #215 I also went through the rest of Item.tsx and added more stopPropagations to prevent the file/directory  from opening when you went to delete and rename files.