### PR TITLE
Iterate styles of prettier error overlay

### DIFF
--- a/src/client/CodeEditor/style.scss
+++ b/src/client/CodeEditor/style.scss
@@ -4,8 +4,12 @@
   font-family: var(--vzcode-font-family);
   overflow-x: auto;
 
-  /* TODO QA this */
   .cm-editor {
     flex: 1;
+  }
+
+  .cm-scroller {
+    font-family: var(--vzcode-font-family);
+    font-size: var(--vzcode-font-size);
   }
 }

--- a/src/client/PrettierErrorOverlay/style.scss
+++ b/src/client/PrettierErrorOverlay/style.scss
@@ -1,9 +1,13 @@
 .prettier-error-overlay {
-  color: rgb(255, 53, 53);
+  color: rgb(255, 35, 35);
+  font-family: var(--vzcode-font-family);
+  font-size: var(--vzcode-font-size);
   background-color: rgba(0, 0, 0, 0.6);
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
   pointer-events: none;
+  margin: 0;
+  padding: 8px;
 }

--- a/src/client/style.scss
+++ b/src/client/style.scss
@@ -1,6 +1,9 @@
 :root {
   --vzcode-font-family: ui-monospace, SFMono-Regular,
     'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace !important;
+
+  --vzcode-font-size: 16px;
+
   /* Variable for the background color */
   --vz-bg-color: rgb(
     41,

--- a/test/sampleDirectories/kitchenSink/index.js
+++ b/test/sampleDirectories/kitchenSink/index.js
@@ -1,1 +1,1 @@
-console.log("Tes  d  ting is a    d file to edit");
+console.log("Tes"  d  ting is a    d file to edit");

--- a/test/sampleDirectories/kitchenSink/index.js
+++ b/test/sampleDirectories/kitchenSink/index.js
@@ -1,1 +1,1 @@
-console.log("Tes"  d  ting is a    d file to edit");
+console.log("Testing this is a file to edit");


### PR DESCRIPTION
Before:

![image](https://github.com/vizhub-core/vzcode/assets/68416/20afd1f3-fe48-44c3-9a8b-1f452be285ad)


After:

![image](https://github.com/vizhub-core/vzcode/assets/68416/569e8b4f-1fd1-4afe-9331-a3e7aedb6d2d)

Closes #259 

Also caught some styling issues with the font in the editor itself.