### PR TITLE
Debounce Prettier on cursor and keyboard events

### DIFF
--- a/src/client/usePrettier/index.ts
+++ b/src/client/usePrettier/index.ts
@@ -128,6 +128,10 @@ export const usePrettier = (
       );
     }
 
+    //Stops prettier from running when you perform a mouse move or a keydown
+    window.addEventListener('mousemove', debouncePrettier);
+    window.addEventListener('keydown', debouncePrettier);
+
     // Listen for changes
     shareDBDoc.on(
       'op batch',
@@ -185,6 +189,14 @@ export const usePrettier = (
       prettierWorker.removeEventListener(
         'message',
         handleMessage,
+      );
+      window.removeEventListener(
+        'keydown',
+        debouncePrettier,
+      );
+      window.removeEventListener(
+        'mousemove',
+        debouncePrettier,
       );
 
       // Clear the timeout


### PR DESCRIPTION
Closes #157 

Added the functionality to stop prettier from running on cursor move and keydown events. Still does not properly handle when others are changing text and waiting on the AI generation. I generally added a keydown event so if a user wants to have prettier run they will need to leave the editor idle (no keyboard inputs or mouse inputs). We can easily change it so it only does it on specific arrow keys if we want. 