### PR TITLE
TypeScript Linter

### DIFF
--- a/src/client/CodeEditor/getOrCreateEditor.ts
+++ b/src/client/CodeEditor/getOrCreateEditor.ts
@@ -10,6 +10,7 @@ import { html } from '@codemirror/lang-html';
 import { css } from '@codemirror/lang-css';
 import { json1Sync } from 'codemirror-ot';
 import { autocompletion } from '@codemirror/autocomplete';
+import { Diagnostic, linter } from '@codemirror/lint';
 import { json1Presence, textUnicode } from '../../ot';
 import {
   FileId,
@@ -32,9 +33,11 @@ import {
 import { ThemeLabel, themeOptionsByLabel } from '../themes';
 import { AIAssist } from '../AIAssist';
 import { typeScriptCompletions } from './typeScriptCompletions';
+import { typeScriptLinter } from './typeScriptLinter';
 
-// Feature flag to enable TypeScript completions.
+// Feature flag to enable TypeScript completions & TypeScript Linter.
 const enableTypeScriptCompletions = true;
+const enableTypeScriptLinter = false;
 
 // Enables TypeScript +JSX support in CodeMirror.
 const tsx = () =>
@@ -240,6 +243,17 @@ export const getOrCreateEditor = ({
           }),
         ],
       }),
+    );
+  }
+  if (enableTypeScriptLinter) {
+    extensions.push(
+      linter(
+          typeScriptLinter({
+            typeScriptWorker,
+            fileName: name,
+            text,
+          }) as unknown as () => Diagnostic[],
+      ),
     );
   }
 

--- a/src/client/CodeEditor/getOrCreateEditor.ts
+++ b/src/client/CodeEditor/getOrCreateEditor.ts
@@ -248,11 +248,12 @@ export const getOrCreateEditor = ({
   if (enableTypeScriptLinter) {
     extensions.push(
       linter(
-          typeScriptLinter({
-            typeScriptWorker,
-            fileName: name,
-            text,
-          }) as unknown as () => Diagnostic[],
+        typeScriptLinter({
+          typeScriptWorker,
+          fileName: name,
+          text,
+        }) as unknown as () => Diagnostic[],
+        //Needs the unknown because we are returning a Promise<Diagnostic>
       ),
     );
   }

--- a/src/client/CodeEditor/getOrCreateEditor.ts
+++ b/src/client/CodeEditor/getOrCreateEditor.ts
@@ -251,7 +251,6 @@ export const getOrCreateEditor = ({
         typeScriptLinter({
           typeScriptWorker,
           fileName: name,
-          text,
         }) as unknown as () => Diagnostic[],
         //Needs the unknown because we are returning a Promise<Diagnostic>
       ),

--- a/src/client/CodeEditor/typeScriptLinter.ts
+++ b/src/client/CodeEditor/typeScriptLinter.ts
@@ -1,0 +1,48 @@
+import { generateRequestId } from './typeScriptCompletions';
+import { LinterResponse } from '../useTypeScript/requestTypes';
+import ts from 'typescript';
+
+export const typeScriptLinter = ({
+  typeScriptWorker,
+  fileName,
+  text,
+}) => {
+  return async () => {
+    const requestId = generateRequestId();
+    typeScriptWorker.postMessage({
+      event: 'lint-request',
+      fileName,
+      fileContent: text,
+      requestId,
+    });
+    //Make sure we are getting the correct postMessage from web worker
+    const tsErrors: ts.Diagnostic[] = await new Promise(
+      (resolve) => {
+        typeScriptWorker.onmessage = (message: {
+          data: LinterResponse;
+        }) => {
+          const ErrorData: LinterResponse = message.data;
+          const { event, requestId, tsErrors } = ErrorData;
+          if (
+            event === 'post-error-linter' &&
+            requestId === requestId
+          ) {
+            resolve(tsErrors);
+          }
+        };
+      },
+    );
+    console.log('Errors received!');
+    //Inspired by: https://stackblitz.com/edit/codemirror-6-typescript?file=client%2Findex.ts%3AL44-L44
+    return tsErrors.map((tsError) => ({
+    from: tsError.start,
+    to: tsError.start + tsError.length,
+    severity: 'error',
+    message:
+      typeof tsError.messageText === 'string'
+        ? tsError.messageText
+        : tsError.messageText.messageText,
+  }));
+
+  };
+};

--- a/src/client/CodeEditor/typeScriptLinter.ts
+++ b/src/client/CodeEditor/typeScriptLinter.ts
@@ -35,7 +35,6 @@ export const typeScriptLinter = ({
         };
       },
     );
-    console.log('Errors received!');
     return tsErrors;
   };
 };

--- a/src/client/CodeEditor/typeScriptLinter.ts
+++ b/src/client/CodeEditor/typeScriptLinter.ts
@@ -34,15 +34,7 @@ export const typeScriptLinter = ({
     );
     console.log('Errors received!');
     //Inspired by: https://stackblitz.com/edit/codemirror-6-typescript?file=client%2Findex.ts%3AL44-L44
-    return tsErrors.map((tsError) => ({
-    from: tsError.start,
-    to: tsError.start + tsError.length,
-    severity: 'error',
-    message:
-      typeof tsError.messageText === 'string'
-        ? tsError.messageText
-        : tsError.messageText.messageText,
-  }));
+    return tsErrors;
 
   };
 };

--- a/src/client/CodeEditor/typeScriptLinter.ts
+++ b/src/client/CodeEditor/typeScriptLinter.ts
@@ -1,5 +1,8 @@
 import { generateRequestId } from './typeScriptCompletions';
-import { LinterResponse } from '../useTypeScript/requestTypes';
+import {
+  LinterResponse,
+  LinterRequest,
+} from '../useTypeScript/requestTypes';
 import ts from 'typescript';
 
 export const typeScriptLinter = ({
@@ -9,13 +12,15 @@ export const typeScriptLinter = ({
 }) => {
   return async () => {
     const requestId = generateRequestId();
-    typeScriptWorker.postMessage({
+    const linterRequest: LinterRequest = {
       event: 'lint-request',
       fileName,
       fileContent: text,
       requestId,
-    });
-    //Make sure we are getting the correct postMessage from web worker
+    };
+    typeScriptWorker.postMessage(linterRequest);
+
+    //An array of diagnostic (CodeMirror) objects.
     const tsErrors: ts.Diagnostic[] = await new Promise(
       (resolve) => {
         typeScriptWorker.onmessage = (message: {
@@ -33,8 +38,6 @@ export const typeScriptLinter = ({
       },
     );
     console.log('Errors received!');
-    //Inspired by: https://stackblitz.com/edit/codemirror-6-typescript?file=client%2Findex.ts%3AL44-L44
     return tsErrors;
-
   };
 };

--- a/src/client/CodeEditor/typeScriptLinter.ts
+++ b/src/client/CodeEditor/typeScriptLinter.ts
@@ -8,14 +8,12 @@ import ts from 'typescript';
 export const typeScriptLinter = ({
   typeScriptWorker,
   fileName,
-  text,
 }) => {
   return async () => {
     const requestId = generateRequestId();
     const linterRequest: LinterRequest = {
       event: 'lint-request',
       fileName,
-      fileContent: text,
       requestId,
     };
     typeScriptWorker.postMessage(linterRequest);

--- a/src/client/useTypeScript/requestTypes.ts
+++ b/src/client/useTypeScript/requestTypes.ts
@@ -17,7 +17,6 @@ export type AutocompleteResponse = {
 export type LinterRequest = {
   event: 'lint-request';
   fileName: string;
-  fileContent: string;
   requestId: string;
 };
 

--- a/src/client/useTypeScript/requestTypes.ts
+++ b/src/client/useTypeScript/requestTypes.ts
@@ -1,3 +1,5 @@
+import ts from 'typescript';
+
 export type AutocompleteRequest = {
   event: 'autocomplete-request';
   fileName: string;
@@ -9,5 +11,18 @@ export type AutocompleteRequest = {
 export type AutocompleteResponse = {
   event: 'post-completions';
   completions: any;
+  requestId: string;
+};
+
+export type LinterRequest = {
+  event: 'lint-request';
+  fileName: string;
+  fileContent: string;
+  requestId: string;
+};
+
+export type LinterResponse = {
+  event: 'post-error-linter';
+  tsErrors: ts.Diagnostic[];
   requestId: string;
 };

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -77,7 +77,7 @@ const setFile = (tsFileName: string, text: string) => {
   }
 };
 
-//Inspired by: https://stackblitz.com/edit/codemirror-6-typescript?file=client%2Findex.ts%3AL44-L44
+// Inspired by: https://stackblitz.com/edit/codemirror-6-typescript?file=client%2Findex.ts%3AL44-L44
 const convertToCodeMirrorDiagnostic = (
   tsErrors: ts.Diagnostic[],
 ) => {

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -76,6 +76,18 @@ const setFile = (tsFileName: string, text: string) => {
   }
 };
 
+const convertToCodeMirrorDiagnostic = (tsErrors: ts.Diagnostic[]) => {
+  return tsErrors.map((tsError: ts.Diagnostic) => ({
+    from: tsError.start,
+    to: tsError.start + tsError.length,
+    severity: 'error',
+    message:
+        typeof tsError.messageText === 'string'
+            ? tsError.messageText
+            : tsError.messageText.messageText,
+  }));
+}
+
 onmessage = async ({ data }) => {
   if (debug) {
     console.log('message received');
@@ -187,6 +199,7 @@ onmessage = async ({ data }) => {
       tsErrors = env.languageService
           .getSemanticDiagnostics(fileName)
           .concat(env.languageService.getSyntacticDiagnostics(fileName));
+      tsErrors =  convertToCodeMirrorDiagnostic(tsErrors);
     }
 
     //tsErrors can not be properly posted currently

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -194,7 +194,7 @@ onmessage = async ({ data }) => {
 
     const tsFileName = getTSFileName(fileName);
     let tsErrors = null;
-    //Since we are also updating the server when we autocomplete we do not need to update
+    // Since we are also updating the server when we autocomplete we do not need to update
     if (isTS(tsFileName)) {
       //Creates an array of diagnostic objects containing
       //both semantic and syntactic diagnostics

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -190,14 +190,12 @@ onmessage = async ({ data }) => {
   if (data.event == 'lint-request') {
     console.log('Lint Request');
     const linterRequest: LinterRequest = data;
-    const { fileName, fileContent, requestId } =
-      linterRequest;
+    const { fileName, requestId } = linterRequest;
 
     const tsFileName = getTSFileName(fileName);
     let tsErrors = null;
+    //Since we are also updating the server when we autocomplete we do not need to update
     if (isTS(tsFileName)) {
-      //Update typescript server
-      setFile(tsFileName, fileContent);
       //Creates an array of diagnostic objects containing
       //both semantic and syntactic diagnostics
       tsErrors = env.languageService
@@ -209,7 +207,6 @@ onmessage = async ({ data }) => {
         );
       tsErrors = convertToCodeMirrorDiagnostic(tsErrors);
     }
-
     //tsErrors can not be properly posted currently
     const linterResponse: LinterResponse = {
       event: 'post-error-linter',

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -188,7 +188,7 @@ onmessage = async ({ data }) => {
   }
 
   if (data.event == 'lint-request') {
-    console.log('Lint Request');
+    if (debug) { console.log('Lint Request'); }
     const linterRequest: LinterRequest = data;
     const { fileName, requestId } = linterRequest;
 

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -196,7 +196,7 @@ onmessage = async ({ data }) => {
     let tsErrors = null;
     // Since we are also updating the server when we autocomplete we do not need to update
     if (isTS(tsFileName)) {
-      //Creates an array of diagnostic objects containing
+      // Creates an array of diagnostic objects containing
       //both semantic and syntactic diagnostics
       tsErrors = env.languageService
         .getSemanticDiagnostics(fileName)

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -207,7 +207,7 @@ onmessage = async ({ data }) => {
         );
       tsErrors = convertToCodeMirrorDiagnostic(tsErrors);
     }
-    //tsErrors can not be properly posted currently
+    // tsErrors can not be properly posted currently
     const linterResponse: LinterResponse = {
       event: 'post-error-linter',
       tsErrors,

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -197,7 +197,7 @@ onmessage = async ({ data }) => {
     // Since we are also updating the server when we autocomplete we do not need to update
     if (isTS(tsFileName)) {
       // Creates an array of diagnostic objects containing
-      //both semantic and syntactic diagnostics
+      // both semantic and syntactic diagnostics.
       tsErrors = env.languageService
         .getSemanticDiagnostics(fileName)
         .concat(


### PR DESCRIPTION
Builds upon #305 and uses our typescript server to now provide linting into our code editor. Utilizes typescript to give more errors that our prettier errors might have missed.  Currently the feature flag for this is set to off and should remain so until we resolve an issue that came up with my implementation.  When inside the editor if a user were to drag and select text and then delete said text it results in the shareDB getting out of sync with the local editor. See attached error:
<img width="412" alt="image" src="https://github.com/vizhub-core/vzcode/assets/28715761/1e96386d-8c85-4f3e-b58c-a8fa4bba910e">

I currently have no ideas to why this might be happening.  The feature flag should not be turned on until this issue is resolved. 