### PR TITLE
TypeScript linter bug fix

### DIFF
--- a/src/client/CodeEditor/getOrCreateEditor.ts
+++ b/src/client/CodeEditor/getOrCreateEditor.ts
@@ -37,7 +37,7 @@ import { typeScriptLinter } from './typeScriptLinter';
 
 // Feature flag to enable TypeScript completions & TypeScript Linter.
 const enableTypeScriptCompletions = true;
-const enableTypeScriptLinter = false;
+const enableTypeScriptLinter = true;
 
 // Enables TypeScript +JSX support in CodeMirror.
 const tsx = () =>
@@ -251,6 +251,8 @@ export const getOrCreateEditor = ({
         typeScriptLinter({
           typeScriptWorker,
           fileName: name,
+          shareDBDoc,
+          fileId,
         }) as unknown as () => Diagnostic[],
         //Needs the unknown because we are returning a Promise<Diagnostic>
       ),

--- a/src/client/CodeEditor/typeScriptLinter.ts
+++ b/src/client/CodeEditor/typeScriptLinter.ts
@@ -8,12 +8,17 @@ import ts from 'typescript';
 export const typeScriptLinter = ({
   typeScriptWorker,
   fileName,
+    shareDBDoc,
+    fileId
 }) => {
   return async () => {
     const requestId = generateRequestId();
+    //Get the fileContent from shareDB to pass to web worker
+    const fileContent = shareDBDoc.data.files[fileId].text;
     const linterRequest: LinterRequest = {
       event: 'lint-request',
       fileName,
+      fileContent,
       requestId,
     };
     typeScriptWorker.postMessage(linterRequest);

--- a/src/client/useTypeScript/requestTypes.ts
+++ b/src/client/useTypeScript/requestTypes.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import {VZCodeContent} from "../../types";
 
 export type AutocompleteRequest = {
   event: 'autocomplete-request';
@@ -17,6 +18,7 @@ export type AutocompleteResponse = {
 export type LinterRequest = {
   event: 'lint-request';
   fileName: string;
+  fileContent: string;
   requestId: string;
 };
 

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -169,7 +169,6 @@ onmessage = async ({ data }) => {
       // absolute latest version. This is critical
       // for correct completions.
       setFile(tsFileName, fileContent);
-      console.log("ADKJGBSDJKGHDS" + fileContent);
 
       completions =
         env.languageService.getCompletionsAtPosition(

--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -169,6 +169,7 @@ onmessage = async ({ data }) => {
       // absolute latest version. This is critical
       // for correct completions.
       setFile(tsFileName, fileContent);
+      console.log("ADKJGBSDJKGHDS" + fileContent);
 
       completions =
         env.languageService.getCompletionsAtPosition(
@@ -192,12 +193,13 @@ onmessage = async ({ data }) => {
       console.log('Lint Request');
     }
     const linterRequest: LinterRequest = data;
-    const { fileName, requestId } = linterRequest;
+    const { fileName, fileContent, requestId } = linterRequest;
 
     const tsFileName = getTSFileName(fileName);
     let tsErrors = null;
     // Since we are also updating the server when we autocomplete we do not need to update
     if (isTS(tsFileName)) {
+      setFile(tsFileName,fileContent);
       // Creates an array of diagnostic objects containing
       // both semantic and syntactic diagnostics.
       tsErrors = env.languageService
@@ -209,7 +211,7 @@ onmessage = async ({ data }) => {
         );
       tsErrors = convertToCodeMirrorDiagnostic(tsErrors);
     }
-    // tsErrors can not be properly posted currently
+
     const linterResponse: LinterResponse = {
       event: 'post-error-linter',
       tsErrors,


### PR DESCRIPTION
Closes #336 

Thanks @curran, your suggestion worked! This gets rid of all the bugs that I found with my testing in the typescript linter. The content that the typescript server was running off of in the linter was out of date and we just needed to update the content with the shareDBDoc. I have also turned the feature flag for the linter on so it will be running in the codebase. 