### PR TITLE
Prevent Unnecessary Completions

### DIFF
--- a/src/client/CodeEditor/typeScriptCompletions.ts
+++ b/src/client/CodeEditor/typeScriptCompletions.ts
@@ -41,6 +41,17 @@ export const typeScriptCompletions = ({
       requestId,
     };
 
+    //Prevent completions from appearing on certain characters
+    if (
+      fileContent[completionContext.pos - 1] === '"' ||
+      fileContent[completionContext.pos - 1] === "'" ||
+      fileContent[completionContext.pos - 1] === ';' ||
+      fileContent[completionContext.pos - 1] === '(' ||
+      fileContent[completionContext.pos - 1] === ')'
+    ) {
+      return { from: completionContext.pos, options: [] };
+    }
+
     //Post message to our sharedWorker to get completions.
     typeScriptWorker.postMessage(autocompleteRequest);
 


### PR DESCRIPTION
Closes #370 

Added some basic conditional logic to prevent the autocompletions from appearing after specific characters (single and double quotes, parentheses, semicolons). Can add onto the conditional if the issue persists on other character types. 