### PR TITLE
Fade Presence Usernames

### DIFF
--- a/src/client/CodeEditor/json1PresenceDisplay.ts
+++ b/src/client/CodeEditor/json1PresenceDisplay.ts
@@ -174,6 +174,12 @@ class PresenceWidget extends WidgetType {
     );
     span.appendChild(userDiv);
 
+    // after 2 seconds of inactivity, username is made less visible
+    setTimeout(() => {
+      userDiv.style.backgroundColor = `rgba(${this.color}, 0.2)`;
+      userDiv.style.color = 'rgba(0,0,0,0.2)';
+    }, 2000);
+
     return span;
   }
 


### PR DESCRIPTION
Goal: make the remote username less visible after 2 seconds of inactivity so that the local user could see all the text in the file without the username blocking it

closes #345