### PR TITLE
Support TypeScript transpilation in Worker

### DIFF
--- a/src/client/useTypeScript/worker.ts
+++ b/src/client/useTypeScript/worker.ts
@@ -244,4 +244,24 @@ onmessage = async ({ data }) => {
     };
     postMessage(linterResponse);
   }
+
+  // Handle the transpile-request event, which
+  // transpiles TypeScript to JavaScript.
+  if (data.event === 'transpile-request') {
+    const tsCode = data.tsCode;
+
+    const compilerOptions = {
+      jsx: ts.JsxEmit.React,
+    };
+
+    const jsCode = ts.transpileModule(tsCode, {
+      compilerOptions,
+    }).outputText;
+
+    postMessage({
+      event: 'transpile-response',
+      jsCode,
+      fileId: data.fileId,
+    });
+  }
 };


### PR DESCRIPTION
This unblocks TypeScript in VizHub.

TS support in VizHub itself has been a long standing issue. I realized that all the pieces are right here in plain sight! As we already are importing the gargantuan `ts` package in this worker, we might as well leverage it for transpilation as well! 