### PR TITLE
Iterate types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,6 @@
 // FileId
 //   * A unique ID for a file.
 
-import { JSONOp } from 'ot-json1';
-
 //   * This is a random string.
 export type FileId = string;
 
@@ -59,6 +57,8 @@ export interface FileTreeFile {
   file: File;
   fileId: FileId;
 }
+
+export type JSONOp = any;
 
 // `ShareDBDoc`
 // A ShareDB Document.

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,7 +142,7 @@ export type AIStreamStatus = {
 export type VZCodeContent = {
   // `files`
   //   * The files in the VZCode instance.
-  files: Files;
+  files?: Files;
 
   // `isInteracting`
   //   * `true` when the user is interacting


### PR DESCRIPTION
I came across a situation where content needs to be `{}`. Modified types to support this.

Also removed broken import.