### PR TITLE
Refactor tab URL params to live inside VZCodeContext

### DIFF
--- a/src/client/App/index.tsx
+++ b/src/client/App/index.tsx
@@ -21,10 +21,6 @@ import {
   VZCodeProvider,
 } from '../VZCodeContext';
 import './style.scss';
-import {
-  useInitialTabs,
-  usePersistTabs,
-} from '../tabsSearchParameters';
 
 // Instantiate the Prettier worker.
 const prettierWorker = new PrettierWorker();
@@ -52,11 +48,9 @@ const connection = new Connection(socket);
 // TODO consider if there's a cleaner pattern for this.
 // This makes sense in VZCode itself, but for an app with
 // authentication that wraps VZCode, it is not required.
-const PersistUsernameAndTabs = () => {
-  const { username, activeFileId, tabList } =
-    useContext(VZCodeContext);
+const PersistUsername = () => {
+  const { username } = useContext(VZCodeContext);
   usePersistUsername(username);
-  usePersistTabs({ activeFileId, tabList });
   return null;
 };
 
@@ -73,12 +67,6 @@ function App() {
 
   // Get the initial username from localStorage.
   const initialUsername: Username = useInitialUsername();
-
-  // get the initial open tabs from the URL
-  const {
-    tabList: initialTabList,
-    activeFileId: initialActiveFileId,
-  } = useInitialTabs();
 
   // Feature flag for enabling the right-side panel.
   // Useful for debugging dual split pane functionality.
@@ -99,8 +87,6 @@ function App() {
         prettierWorker={prettierWorker}
         typeScriptWorker={typeScriptWorker}
         initialUsername={initialUsername}
-        initialTabList={initialTabList}
-        initialActiveFileId={initialActiveFileId}
       >
         <div className="app">
           <VZLeft />
@@ -111,7 +97,7 @@ function App() {
             <VZResizer side="right" />
           ) : null}
         </div>
-        <PersistUsernameAndTabs />
+        <PersistUsername />
       </VZCodeProvider>
     </SplitPaneResizeProvider>
   );

--- a/src/client/VZCodeContext.tsx
+++ b/src/client/VZCodeContext.tsx
@@ -1,11 +1,5 @@
+import { createContext, useReducer } from 'react';
 import {
-  createContext,
-  useEffect,
-  useReducer,
-  useRef,
-} from 'react';
-import {
-  FileId,
   Files,
   ShareDBDoc,
   Username,
@@ -30,6 +24,10 @@ import {
   EditorCache,
   useEditorCache,
 } from './useEditorCache';
+import {
+  useInitialTabs,
+  usePersistTabs,
+} from './tabsSearchParameters';
 
 // This context centralizes all the "smart" logic
 // to do with the application state. This includes
@@ -98,8 +96,6 @@ export const VZCodeProvider = ({
   prettierWorker,
   typeScriptWorker,
   initialUsername,
-  initialTabList,
-  initialActiveFileId,
   children,
   codeError = null,
   enableManualPretter = false,
@@ -114,8 +110,6 @@ export const VZCodeProvider = ({
   prettierWorker: Worker;
   typeScriptWorker: Worker;
   initialUsername: Username;
-  initialTabList: TabState[];
-  initialActiveFileId: FileId | null;
   children: React.ReactNode;
   codeError?: string | null;
   enableManualPretter?: boolean;
@@ -152,6 +146,12 @@ export const VZCodeProvider = ({
     typeScriptWorker,
   });
 
+  // Get the initial open tabs from the URL
+  const {
+    tabList: initialTabList,
+    activeFileId: initialActiveFileId,
+  } = useInitialTabs();
+
   // Set up the reducer that manages much of the application state.
   // See https://react.dev/reference/react/useReducer
   const [state, dispatch] = useReducer(
@@ -174,6 +174,9 @@ export const VZCodeProvider = ({
     editorWantsFocus,
     username,
   } = state;
+
+  // Sync tab state to the URL
+  usePersistTabs({ activeFileId, tabList });
 
   // Functions for dispatching actions to the reducer.
   const {


### PR DESCRIPTION
Moved the URL param handling into VZCodeContext, so that this feature is automatically added in downstream code that instantiates this context.