### PR TITLE
Wrap long lines in CodeMirror tooltips

### DIFF
--- a/src/client/CodeEditor/style.scss
+++ b/src/client/CodeEditor/style.scss
@@ -20,4 +20,8 @@
     justify-content: center;
     border-radius: 4px;
   }
+
+  .cm-tooltip-lint {
+    max-width: 500px;
+  }
 }


### PR DESCRIPTION
Closes #468 

![image](https://github.com/vizhub-core/vzcode/assets/68416/62754c35-0e72-4adb-aa6b-2c657801fac8)
