### PR TITLE
stable-layout v3

### DIFF
--- a/src/client/VZSidebar/Item.tsx
+++ b/src/client/VZSidebar/Item.tsx
@@ -149,6 +149,7 @@ export const Item = ({
       <div className="name">
         {isRenaming ? (
           <input
+            className="rename-input"
             ref={renameInputRef}
             type="text"
             aria-label="Field name"

--- a/src/client/VZSidebar/styles.scss
+++ b/src/client/VZSidebar/styles.scss
@@ -88,6 +88,12 @@
     }
   }
 
+  .rename-input {
+    padding: 0px;
+    border: 0px;
+    margin: 0px;
+  }
+
   .indentation {
     margin-left: 20px;
   }


### PR DESCRIPTION
As I was trying to find another solution besides setting a hard code height for the className="name", when editing the file's name it doesn't shift the vertical layout anymore. However, I still decided to add no padding, border, and margin to the input field so that it will try to match the UI's height. As per the original input field had a height of around 30. Now it reduced to 24 to match the UI's height.