### PR TITLE
Support read-only view when no ShareDB doc

### DIFF
--- a/src/client/CodeEditor/getOrCreateEditor.ts
+++ b/src/client/CodeEditor/getOrCreateEditor.ts
@@ -150,24 +150,32 @@ export const getOrCreateEditor = ({
         textUnicode,
       }),
     );
-  }
 
-  // Deals with broadcasting changes in cursor location and selection.
-  if (localPresence) {
-    extensions.push(
-      json1PresenceBroadcast({
-        path: textPath,
-        localPresence,
-        usernameRef,
-      }),
-    );
-  }
+    // Deals with broadcasting changes in cursor location and selection.
+    if (localPresence) {
+      extensions.push(
+        json1PresenceBroadcast({
+          path: textPath,
+          localPresence,
+          usernameRef,
+        }),
+      );
+    }
 
-  // Deals with receiving the broadcas from other clients and displaying them.
-  if (docPresence)
-    extensions.push(
-      json1PresenceDisplay({ path: textPath, docPresence }),
-    );
+    // Deals with receiving the broadcas from other clients and displaying them.
+    if (docPresence) {
+      extensions.push(
+        json1PresenceDisplay({
+          path: textPath,
+          docPresence,
+        }),
+      );
+    }
+  } else {
+    // If the ShareDB document is not provided,
+    // then we do not allow editing.
+    extensions.push(EditorView.editable.of(false));
+  }
 
   extensions.push(colorsInTextPlugin);
 

--- a/src/client/CodeEditor/getOrCreateEditor.ts
+++ b/src/client/CodeEditor/getOrCreateEditor.ts
@@ -80,6 +80,7 @@ const getAtPath = (obj, path) => {
 export const getOrCreateEditor = ({
   fileId,
   shareDBDoc,
+  content,
   filesPath,
   localPresence,
   docPresence,
@@ -98,7 +99,13 @@ export const getOrCreateEditor = ({
   //    based on the file extension.
   // It's also passed into the `json1Sync` extension,
   // which is used for multiplayer editing.
-  shareDBDoc: ShareDBDoc<VZCodeContent>;
+  // This can be `undefined` in the case where we are
+  // viewing files read-only, in which case multiplayer
+  // editing is not enabled.
+  shareDBDoc: ShareDBDoc<VZCodeContent> | undefined;
+
+  // The initial content to present.
+  content: VZCodeContent;
 
   filesPath: string[];
   localPresence: any;
@@ -118,11 +125,10 @@ export const getOrCreateEditor = ({
   // Cache miss
 
   // Compute `text` and `fileExtension` from the ShareDB document.
-  const data = shareDBDoc.data;
   const textPath = [...filesPath, fileId, 'text'];
   const namePath = [...filesPath, fileId, 'name'];
-  const text = getAtPath(data, textPath);
-  const name = getAtPath(data, namePath);
+  const text = getAtPath(content, textPath);
+  const name = getAtPath(content, namePath);
   const fileExtension = name.split('.').pop();
 
   // Create a compartment for the theme so that it can be changed dynamically.
@@ -135,14 +141,16 @@ export const getOrCreateEditor = ({
   // This plugin implements multiplayer editing,
   // real-time synchronozation of changes across clients.
   // Does not deal with showing others' cursors.
-  extensions.push(
-    json1Sync({
-      shareDBDoc,
-      path: textPath,
-      json1: json1Presence,
-      textUnicode,
-    }),
-  );
+  if (shareDBDoc) {
+    extensions.push(
+      json1Sync({
+        shareDBDoc,
+        path: textPath,
+        json1: json1Presence,
+        textUnicode,
+      }),
+    );
+  }
 
   // Deals with broadcasting changes in cursor location and selection.
   if (localPresence) {
@@ -247,7 +255,7 @@ export const getOrCreateEditor = ({
       }),
     );
   }
-  if (enableTypeScriptLinter) {
+  if (shareDBDoc && enableTypeScriptLinter) {
     extensions.push(
       linter(
         typeScriptLinter({

--- a/src/client/CodeEditor/index.tsx
+++ b/src/client/CodeEditor/index.tsx
@@ -3,66 +3,32 @@ import {
   useLayoutEffect,
   useCallback,
   useMemo,
+  useContext,
 } from 'react';
-import {
-  FileId,
-  ShareDBDoc,
-  Username,
-  VZCodeContent,
-} from '../../types';
-import { ThemeLabel, defaultTheme } from '../themes';
-import {
-  EditorCache,
-  EditorCacheValue,
-} from '../useEditorCache';
+import { Username } from '../../types';
+import { EditorCacheValue } from '../useEditorCache';
 import { getOrCreateEditor } from './getOrCreateEditor';
+import { VZCodeContext } from '../VZCodeContext';
 import './style.scss';
 
-export const CodeEditor = ({
-  activeFileId,
-  shareDBDoc,
-  submitOperation,
-  localPresence,
-  docPresence,
-  theme = defaultTheme,
-  filesPath = ['files'],
-  editorCache,
-  editorWantsFocus,
-  editorNoLongerWantsFocus,
-  username,
-  typeScriptWorker,
-}: {
-  activeFileId: FileId;
-  shareDBDoc: ShareDBDoc<VZCodeContent> | null;
-  submitOperation: (
-    next: (content: VZCodeContent) => VZCodeContent,
-  ) => void;
-  localPresence?: any;
-  docPresence?: any;
-  theme?: ThemeLabel;
+// The path in the ShareDB document where the files live.
+const filesPath = ['files'];
 
-  // The path of the files object in the ShareDB document.
-  // Defaults to `files` if not provided.
-  filesPath?: string[];
-  editorCache: EditorCache;
+export const CodeEditor = () => {
+  const {
+    activeFileId,
+    shareDBDoc,
+    submitOperation,
+    localPresence,
+    docPresence,
+    username,
+    editorCache,
+    editorWantsFocus,
+    editorNoLongerWantsFocus,
+    typeScriptWorker,
+    theme,
+  } = useContext(VZCodeContext);
 
-  // Whether the editor should be focused.
-  editorWantsFocus: boolean;
-
-  // Signals that the editor no longer wants focus.
-  editorNoLongerWantsFocus: () => void;
-  username: Username;
-
-  // The server endpoint for the AI Assist service.
-  aiAssistEndpoint?: string;
-
-  // Additional options to pass to the AI Assist service,
-  // an object with string values.
-  aiAssistOptions?: {
-    [key: string]: string;
-  };
-  typeScriptWorker: Worker;
-}) => {
   const ref = useRef<HTMLDivElement>(null);
 
   // Set `doc.data.isInteracting` to `true` when the user is interacting

--- a/src/client/CodeEditor/index.tsx
+++ b/src/client/CodeEditor/index.tsx
@@ -100,7 +100,7 @@ export const CodeEditor = () => {
   useLayoutEffect(() => {
     // Guard against cases where page is still loading.
     if (!ref.current) return;
-    if (!shareDBDoc) return;
+    if (!content) return;
 
     // Add the editor to the DOM.
     ref.current.appendChild(editorCacheValue.editor.dom);

--- a/src/client/CodeEditor/index.tsx
+++ b/src/client/CodeEditor/index.tsx
@@ -18,6 +18,7 @@ export const CodeEditor = () => {
   const {
     activeFileId,
     shareDBDoc,
+    content,
     submitOperation,
     localPresence,
     docPresence,
@@ -69,6 +70,7 @@ export const CodeEditor = () => {
       getOrCreateEditor({
         fileId: activeFileId,
         shareDBDoc,
+        content,
         filesPath,
         localPresence,
         docPresence,

--- a/src/client/VZCodeContext.tsx
+++ b/src/client/VZCodeContext.tsx
@@ -91,7 +91,10 @@ export type VZCodeContextValue = {
   toggleDirectory: (path: string) => void;
 
   editorCache: EditorCache;
+
+  // Whether the editor should be focused.
   editorWantsFocus: boolean;
+  // Signals that the editor no longer wants focus.
   editorNoLongerWantsFocus: () => void;
 
   errorMessage: string | null;

--- a/src/client/VZMiddle.tsx
+++ b/src/client/VZMiddle.tsx
@@ -76,21 +76,7 @@ export const VZMiddle = ({
         createFile={createFile}
       />
       {isClient && content && activeFileId && (
-        <CodeEditor
-          shareDBDoc={shareDBDoc}
-          submitOperation={submitOperation}
-          localPresence={localPresence}
-          docPresence={docPresence}
-          activeFileId={activeFileId}
-          theme={theme}
-          editorCache={editorCache}
-          editorWantsFocus={editorWantsFocus}
-          editorNoLongerWantsFocus={
-            editorNoLongerWantsFocus
-          }
-          username={username}
-          typeScriptWorker={typeScriptWorker}
-        />
+        <CodeEditor />
       )}
       {isClient &&
       enableAIAssist &&


### PR DESCRIPTION
This change is to support a read-only view, used in VizHub for the "view previous version" of revision history feature.

Related to #471