### PR TITLE
Preserve scroll across files

### DIFF
--- a/src/client/CodeEditor/index.tsx
+++ b/src/client/CodeEditor/index.tsx
@@ -112,24 +112,14 @@ export const CodeEditor = ({
     if (!ref.current) return;
     if (!content) return;
 
-    // Add the editor to the DOM.
+    // Add the editor and apply the prior scroll position to the DOM.
     ref.current.appendChild(editorCacheValue.editor.dom);
-
-    // Set the prior line position of the non-active document
-    const editor = editorCacheValue.editor;
-    const cursor = editor.state.selection.main.head;
-    const line = editor.state.doc.lineAt(cursor).number;
-
-    editor.dispatch({
-      effects: EditorView.scrollIntoView(editor.state.doc.line(line).from, {
-        y: 'center',
-        x: 'center'
-      })
-    });
+    editorCacheValue.editor.scrollDOM.scrollTo({top: editorCacheValue.position ?? 0});
     
     return () => {
-      // Remove the old editor from the DOM.
+      // Remove the old editor from the DOM and store the current scroll position.
       // This happens every time `activeFileId` changes.
+      editorCacheValue.position = editorCacheValue.editor.scrollDOM.scrollTop;
       ref.current.removeChild(editorCacheValue.editor.dom);
     };
   }, [shareDBDoc, editorCacheValue]);

--- a/src/client/CodeEditor/index.tsx
+++ b/src/client/CodeEditor/index.tsx
@@ -5,7 +5,6 @@ import {
   useMemo,
   useContext,
 } from 'react';
-import { EditorView } from 'codemirror';
 import { Username } from '../../types';
 import { EditorCacheValue } from '../useEditorCache';
 import { getOrCreateEditor } from './getOrCreateEditor';
@@ -114,12 +113,12 @@ export const CodeEditor = ({
 
     // Add the editor and apply the prior scroll position to the DOM.
     ref.current.appendChild(editorCacheValue.editor.dom);
-    editorCacheValue.editor.scrollDOM.scrollTo({top: editorCacheValue.position ?? 0});
+    editorCacheValue.editor.scrollDOM.scrollTo({top: editorCacheValue.scrollPosition ?? 0});
     
     return () => {
       // Remove the old editor from the DOM and store the current scroll position.
       // This happens every time `activeFileId` changes.
-      editorCacheValue.position = editorCacheValue.editor.scrollDOM.scrollTop;
+      editorCacheValue.scrollPosition = editorCacheValue.editor.scrollDOM.scrollTop;
       ref.current.removeChild(editorCacheValue.editor.dom);
     };
   }, [shareDBDoc, editorCacheValue]);

--- a/src/client/CodeEditor/index.tsx
+++ b/src/client/CodeEditor/index.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useContext,
 } from 'react';
+import { EditorView } from 'codemirror';
 import { Username } from '../../types';
 import { EditorCacheValue } from '../useEditorCache';
 import { getOrCreateEditor } from './getOrCreateEditor';
@@ -114,6 +115,18 @@ export const CodeEditor = ({
     // Add the editor to the DOM.
     ref.current.appendChild(editorCacheValue.editor.dom);
 
+    // Set the prior line position of the non-active document
+    const editor = editorCacheValue.editor;
+    const cursor = editor.state.selection.main.head;
+    const line = editor.state.doc.lineAt(cursor).number;
+
+    editor.dispatch({
+      effects: EditorView.scrollIntoView(editor.state.doc.line(line).from, {
+        y: 'center',
+        x: 'center'
+      })
+    });
+    
     return () => {
       // Remove the old editor from the DOM.
       // This happens every time `activeFileId` changes.

--- a/src/client/useEditorCache.ts
+++ b/src/client/useEditorCache.ts
@@ -5,7 +5,7 @@ import { EditorView } from 'codemirror';
 export type EditorCacheValue = {
   editor: EditorView;
   themeCompartment: any;
-  position?: number;
+  scrollPosition?: number;
 };
 
 export type EditorCache = Map<FileId, EditorCacheValue>;

--- a/src/client/useEditorCache.ts
+++ b/src/client/useEditorCache.ts
@@ -5,6 +5,7 @@ import { EditorView } from 'codemirror';
 export type EditorCacheValue = {
   editor: EditorView;
   themeCompartment: any;
+  position?: number;
 };
 
 export type EditorCache = Map<FileId, EditorCacheValue>;


### PR DESCRIPTION
The proposed changes will ensure that the current scroll position for the active file will be cached when removing the editor from the DOM. The cached scroll position is applied when switching between files and opening closed files. 