### PR TITLE
Jump to definition

### DIFF
--- a/src/client/VZCodeContext.tsx
+++ b/src/client/VZCodeContext.tsx
@@ -316,6 +316,7 @@ export const VZCodeProvider = ({
     setActiveFileRight,
     runPrettierRef,
     runCodeRef,
+    editorCache
   });
 
   // Track the currently hovered file id.


### PR DESCRIPTION
This implementation will allow users to use CTRL + Click when targetting an identifier within the current code editor to jump to its definition for various identifier types, such as variables, methods, and properties.