### PR TITLE
fixed the wrong port opening in development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test-interactive": "cd test/sampleDirectories/kitchenSink && node ../../../src/server/index.js",
     "prettier": "prettier {*.*,**/*.*} --write",
     "tsc": "tsc --noEmit",
-    "dev": "concurrently \"npm run test-interactive\" \"vite\"",
+    "dev": "EDITOR_PORT=5173 concurrently \"npm run test-interactive\" \"vite\"",
     "build": "vite build",
     "build-release": "vite build --mode release",
     "preview": "concurrently \"npm run test-interactive\" \"vite preview\"",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -310,9 +310,12 @@ server.listen(port, async () => {
       open(url);
     })();
   } else {
+    // Sets the port to the one specified in the environment 
+    // variable (for development) or the default port.
+    let livePort = process.env.EDITOR_PORT || port;
     console.log(
-      `Editor is live at http://localhost:${port}`,
+      `Editor is live at http://localhost:${livePort}`,
     );
-    open(`http://localhost:${port}`);
+    open(`http://localhost:${livePort}`);
   }
 });


### PR DESCRIPTION
I added a new environment variable for the editor port to be 5173. The index.js file then checks the editor port variable and defaults to the current port if one is not specified.