### PR TITLE
TypeScript Language Server Breakages

### DIFF
--- a/src/client/useTypeScript/worker/constants.ts
+++ b/src/client/useTypeScript/worker/constants.ts
@@ -1,7 +1,8 @@
 import ts from 'typescript';
 
 export const compilerOptions: ts.CompilerOptions = {
-  lib: ['dom', 'esnext'],
+  target: ts.ScriptTarget.ES2022,
+  lib: ['dom', 'es2022'],
 
   // Disable warnings around "Any type".
   noImplicitAny: false,


### PR DESCRIPTION
Fix #770

Inspired by https://github.com/val-town/codemirror-ts?tab=readme-ov-file#setup-main-thread

The `esnext` is what apparently was missing some definitions. Changing it to es2022 and setting the target seems to have fixed it.