### PR TITLE
Keyboard Shortcuts for Sidebar

### DIFF
--- a/src/client/VZKeyboardShortcutsDoc.tsx
+++ b/src/client/VZKeyboardShortcutsDoc.tsx
@@ -69,7 +69,7 @@ export const VZKeyboardShortcutsDoc = ({
               <span>Close the current tab</span>
             </li>
             <li>
-              <strong>Alt + n</strong> <br />
+              <strong>Alt + n or Ctrl + Shift + n</strong> <br />
               <span>Open the create file modal</span>
             </li>
             <li>
@@ -83,6 +83,10 @@ export const VZKeyboardShortcutsDoc = ({
               <span>
                 Change the active tab to the next one
               </span>
+            </li>
+            <li>
+              <strong>Ctrl + Shift + &lt;key&gt;</strong> <br />
+              <span>Click sidebar icon with <strong>e</strong> (Files), <strong>f</strong> (Search), <strong>k</strong> (Keyboard Shortcuts), <strong>b</strong> (Report Bugs), <strong>s</strong> (Settings), <strong>n</strong> (New File), <strong>d</strong> (New Directory), <strong>a</strong> (Auto-focus)</span>
             </li>
             <li>
               <strong>Most VSCode Shortcuts</strong> <br />

--- a/src/client/VZSidebar/index.tsx
+++ b/src/client/VZSidebar/index.tsx
@@ -135,8 +135,9 @@ export const VZSidebar = ({
             }
           >
             <i
-              onClick={() => setIsSearchOpen(false)}
+              id="files-icon"
               className="icon-button icon-button-dark"
+              onClick={() => setIsSearchOpen(false)}
             >
               <FolderSVG />
             </i>
@@ -151,8 +152,9 @@ export const VZSidebar = ({
             }
           >
             <i
-              onClick={() => setIsSearchOpen(true)}
+              id="search-icon"
               className="icon-button icon-button-dark"
+              onClick={() => setIsSearchOpen(true)}
             >
               <SearchSVG />
             </i>
@@ -167,8 +169,9 @@ export const VZSidebar = ({
             }
           >
             <i
-              onClick={handleQuestionMarkClick}
+              id="shortcut-icon"
               className="icon-button icon-button-dark"
+              onClick={handleQuestionMarkClick}
             >
               <QuestionMarkSVG />
             </i>
@@ -187,7 +190,9 @@ export const VZSidebar = ({
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i className="icon-button icon-button-dark">
+              <i 
+                id="bug-icon"
+                className="icon-button icon-button-dark">
                 <BugSVG />
               </i>
             </a>
@@ -202,8 +207,9 @@ export const VZSidebar = ({
             }
           >
             <i
-              onClick={handleSettingsClick}
+              id="settings-icon"
               className="icon-button icon-button-dark"
+              onClick={handleSettingsClick}
             >
               <GearSVG />
             </i>
@@ -218,8 +224,9 @@ export const VZSidebar = ({
             }
           >
             <i
-              onClick={handleOpenCreateFileModal}
+              id="new-file-icon"
               className="icon-button icon-button-dark"
+              onClick={handleOpenCreateFileModal}
             >
               <NewSVG />
             </i>
@@ -235,8 +242,10 @@ export const VZSidebar = ({
             }
           >
             <i
-              onClick={handleOpenCreateDirModal}
+              id="new-directory-icon"
+              
               className="icon-button icon-button-dark"
+              onClick={handleOpenCreateDirModal}
             >
               <FileSVG />
             </i>
@@ -254,12 +263,13 @@ export const VZSidebar = ({
             }
           >
             <i
-              onClick={toggleAutoFollow}
+              id="auto-focus-icon"
               className={`icon-button icon-button-dark${
                 enableAutoFollow
                   ? ' vh-color-success-01'
                   : ''
               }`}
+              onClick={toggleAutoFollow}
             >
               <PinSVG />
             </i>

--- a/src/client/useKeyboardShortcuts.ts
+++ b/src/client/useKeyboardShortcuts.ts
@@ -151,6 +151,18 @@ function jumpToDefinition(
   }
 }
 
+// Sidebar keyboard shortcuts in form Ctrl + Shift + <key>
+const sideBarKeyBoardMap = {
+  'E': 'files-icon',
+  'F': 'search-icon',
+  'K': 'shortcut-icon',
+  'B': 'bug-icon',
+  'S': 'settings-icon',
+  'N': 'new-file-icon',
+  'D': 'new-directory-icon',
+  'A': 'auto-focus-icon'
+};
+
 // This module implements the keyboard shortcuts
 // for the VZCode editor.
 // These include:
@@ -201,6 +213,11 @@ export const useKeyboardShortcuts = ({
           runCode();
         }
         return;
+      }
+      
+      if (event.ctrlKey && event.shiftKey) {
+        // Handle keyboard shortcuts related to the side bar icons
+        document.getElementById(sideBarKeyBoardMap[event.key])?.click();
       }
 
       if (event.ctrlKey === true) {


### PR DESCRIPTION
The following adds a keyboard shortcut to trigger any sidebar buttons in the form `Ctrl + Shift + <key>`, where the shortcut model has been appended to contain information on these triggers.