### PR TITLE
Update Sidebar Button Tooltips

### DIFF
--- a/src/client/VZKeyboardShortcutsDoc.tsx
+++ b/src/client/VZKeyboardShortcutsDoc.tsx
@@ -85,10 +85,6 @@ export const VZKeyboardShortcutsDoc = ({
               </span>
             </li>
             <li>
-              <strong>Ctrl + Shift + &lt;key&gt;</strong> <br />
-              <span>Click sidebar icon with <strong>e</strong> (Files), <strong>f</strong> (Search), <strong>k</strong> (Keyboard Shortcuts), <strong>b</strong> (Report Bugs), <strong>s</strong> (Settings), <strong>n</strong> (New File), <strong>d</strong> (New Directory), <strong>a</strong> (Auto-focus)</span>
-            </li>
-            <li>
               <strong>Most VSCode Shortcuts</strong> <br />
               See VSCode docs:{' '}
               <a

--- a/src/client/VZSidebar/index.tsx
+++ b/src/client/VZSidebar/index.tsx
@@ -35,7 +35,12 @@ import './styles.scss';
 const enableConnectionStatus = true;
 
 export const VZSidebar = ({
-  createFileTooltipText = 'New File (Ctrl + Shift + N)',
+  createFileTooltipText = (
+    <>
+      <strong>New file</strong>
+      <div>(Ctrl + Shift + N)</div>
+    </>
+  ),
   createDirTooltipText = 'New Directory (Ctrl + Shift + D)',
   openSettingsTooltipText = 'Open Settings (Ctrl + Shift + S or Ctrl + ,)',
   openKeyboardShortcuts = 'Keyboard Shortcuts (Ctrl + Shift + K)',
@@ -43,7 +48,7 @@ export const VZSidebar = ({
   searchToolTipText = 'Search (Ctrl + Shift + F)',
   filesToolTipText = 'Files (Ctrl + Shift + E)',
 }: {
-  createFileTooltipText?: string;
+  createFileTooltipText?: React.ReactNode;
   createDirTooltipText?: string;
   openSettingsTooltipText?: string;
   reportBugTooltipText?: string;
@@ -190,9 +195,10 @@ export const VZSidebar = ({
               target="_blank"
               rel="noopener noreferrer"
             >
-              <i 
+              <i
                 id="bug-icon"
-                className="icon-button icon-button-dark">
+                className="icon-button icon-button-dark"
+              >
                 <BugSVG />
               </i>
             </a>

--- a/src/client/VZSidebar/index.tsx
+++ b/src/client/VZSidebar/index.tsx
@@ -35,13 +35,13 @@ import './styles.scss';
 const enableConnectionStatus = true;
 
 export const VZSidebar = ({
-  createFileTooltipText = 'New File',
-  createDirTooltipText = 'New Directory',
-  openSettingsTooltipText = 'Open Settings',
-  openKeyboardShortcuts = 'Keyboard Shortcuts',
-  reportBugTooltipText = 'Report Bug',
-  searchToolTipText = 'Search',
-  filesToolTipText = 'Files',
+  createFileTooltipText = 'New File (Ctrl + Shift + N)',
+  createDirTooltipText = 'New Directory (Ctrl + Shift + D)',
+  openSettingsTooltipText = 'Open Settings (Ctrl + Shift + S or Ctrl + ,)',
+  openKeyboardShortcuts = 'Keyboard Shortcuts (Ctrl + Shift + K)',
+  reportBugTooltipText = 'Report Bug (Ctrl + Shift + B)',
+  searchToolTipText = 'Search (Ctrl + Shift + F)',
+  filesToolTipText = 'Files (Ctrl + Shift + E)',
 }: {
   createFileTooltipText?: string;
   createDirTooltipText?: string;
@@ -243,7 +243,6 @@ export const VZSidebar = ({
           >
             <i
               id="new-directory-icon"
-              
               className="icon-button icon-button-dark"
               onClick={handleOpenCreateDirModal}
             >
@@ -257,8 +256,8 @@ export const VZSidebar = ({
             overlay={
               <Tooltip id="toggle-auto-follow">
                 {enableAutoFollow
-                  ? 'Disable Auto Follow'
-                  : 'Enable Auto Follow'}
+                  ? 'Disable Auto Follow (Ctrl + Shift + A)'
+                  : 'Enable Auto Follow (Ctrl + Shift + A)'}
               </Tooltip>
             }
           >

--- a/src/client/useKeyboardShortcuts.ts
+++ b/src/client/useKeyboardShortcuts.ts
@@ -218,8 +218,10 @@ export const useKeyboardShortcuts = ({
       if (event.ctrlKey && event.shiftKey) {
         // Handle keyboard shortcuts related to the side bar icons
         document.getElementById(sideBarKeyBoardMap[event.key])?.click();
-      }
-
+      } else if (event.ctrlKey && event.key === ',') {
+        document.getElementById(sideBarKeyBoardMap['S'])?.click();
+      } 
+      
       if (event.ctrlKey === true) {
         // On holding CTRL key, search for a potential definition jump using mouse location
         document.addEventListener(


### PR DESCRIPTION
The following updates each sidebar button tooltip to display their respective keyboard shortcut. An additional shortcut (`Ctrl +,`) to trigger the settings view was also added, which is based on the VS Code implementation. This fixes [#789](https://github.com/vizhub-core/vzcode/issues/789) and potentially removes the need for [#790](https://github.com/vizhub-core/vzcode/issues/790) due to the complexity of total shortcuts to represent.