### PR TITLE
Change state shape in preparation for split pane views

### DIFF
--- a/src/client/AIAssist/AIAssistCodeMirrorKeyMap.ts
+++ b/src/client/AIAssist/AIAssistCodeMirrorKeyMap.ts
@@ -1,6 +1,9 @@
 import { EditorView, keymap } from '@codemirror/view';
-import { ShareDBDoc, VZCodeContent } from '../../types';
-import { TabState } from '../vzReducer';
+import {
+  ShareDBDoc,
+  TabState,
+  VZCodeContent,
+} from '../../types';
 
 export const AIAssistCodeMirrorKeyMap = ({
   shareDBDoc,

--- a/src/client/AIAssist/startAIAssist.ts
+++ b/src/client/AIAssist/startAIAssist.ts
@@ -3,9 +3,9 @@ import {
   File,
   FileId,
   ShareDBDoc,
+  TabState,
   VZCodeContent,
 } from '../../types';
-import { TabState } from '../vzReducer';
 import { RequestId } from '../generateRequestId';
 import { formatFile } from './formatFile';
 

--- a/src/client/CodeEditor/getOrCreateEditor.ts
+++ b/src/client/CodeEditor/getOrCreateEditor.ts
@@ -19,6 +19,7 @@ import { json1Presence, textUnicode } from '../../ot';
 import {
   FileId,
   ShareDBDoc,
+  TabState,
   Username,
   VZCodeContent,
 } from '../../types';
@@ -40,7 +41,6 @@ import { keymap } from '@codemirror/view';
 import { basicSetup } from './basicSetup';
 import { InteractRule } from '@replit/codemirror-interact';
 import rainbowBrackets from '../CodeEditor/rainbowBrackets';
-import { TabState } from '../vzReducer';
 import { cssLanguage } from '@codemirror/lang-css';
 import { javascriptLanguage } from '@codemirror/lang-javascript';
 

--- a/src/client/CodeEditor/json1PresenceDisplay.ts
+++ b/src/client/CodeEditor/json1PresenceDisplay.ts
@@ -10,9 +10,9 @@ import {
   FileId,
   Presence,
   PresenceId,
+  TabState,
   Username,
 } from '../../types';
-import { TabState } from '../vzReducer';
 
 const debug = false;
 

--- a/src/client/TabList/Tab.tsx
+++ b/src/client/TabList/Tab.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import type { FileId } from '../../types';
-import type { TabState } from '../vzReducer';
+import type { FileId, TabState } from '../../types';
 import { CloseSVG } from '../Icons';
 
 // Supports adding the file's containing folder to the tab name

--- a/src/client/TabList/index.tsx
+++ b/src/client/TabList/index.tsx
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
 import { VZCodeContext } from '../VZCodeContext';
-import { TabState } from '../vzReducer';
 import { Tab } from './Tab';
 import './style.scss';
+import { TabState } from '../../types';
 
 // Displays the list of tabs above the code editor.
 export const TabList = () => {

--- a/src/client/VZCodeContext.tsx
+++ b/src/client/VZCodeContext.tsx
@@ -226,7 +226,7 @@ export const VZCodeProvider = ({
 
   // Unpack state.
   const {
-    tabList,
+    pane,
     activeFileId,
     theme,
     search,
@@ -237,6 +237,12 @@ export const VZCodeProvider = ({
     username,
     enableAutoFollow,
   } = state;
+
+  // TODO support splitPane
+  if (pane.type !== 'leafPane') {
+    throw new Error('Expected leafPane');
+  }
+  const tabList = pane.tabList;
 
   // Functions for dispatching actions to the reducer.
   const {

--- a/src/client/VZCodeContext.tsx
+++ b/src/client/VZCodeContext.tsx
@@ -14,14 +14,11 @@ import {
   VZCodeContent,
   SearchResults,
   SearchFileVisibility,
+  TabState,
 } from '../types';
 import { usePrettier } from './usePrettier';
 import { useTypeScript } from './useTypeScript';
-import {
-  TabState,
-  createInitialState,
-  vzReducer,
-} from './vzReducer';
+import { createInitialState, vzReducer } from './vzReducer';
 import {
   ThemeLabel,
   defaultTheme,
@@ -227,7 +224,6 @@ export const VZCodeProvider = ({
   // Unpack state.
   const {
     pane,
-    activeFileId,
     theme,
     search,
     isSearchOpen,
@@ -238,11 +234,12 @@ export const VZCodeProvider = ({
     enableAutoFollow,
   } = state;
 
-  // TODO support splitPane
+  // TODO support splitPane type
   if (pane.type !== 'leafPane') {
     throw new Error('Expected leafPane');
   }
   const tabList = pane.tabList;
+  const activeFileId = pane.activeFileId;
 
   // Functions for dispatching actions to the reducer.
   const {

--- a/src/client/tabsSearchParameters.ts
+++ b/src/client/tabsSearchParameters.ts
@@ -1,5 +1,4 @@
-import { FileId, VZCodeContent } from '../types';
-import { TabState } from './vzReducer';
+import { FileId, TabState, VZCodeContent } from '../types';
 
 // The delimiter used to separate file names in the `tabs` parameter.
 // We need a character that is both URL-safe (does not get escaped in URLs)

--- a/src/client/useActions.ts
+++ b/src/client/useActions.ts
@@ -4,10 +4,11 @@ import {
   FileId,
   SearchFileVisibility,
   ShareDBDoc,
+  TabState,
   Username,
   VZCodeContent,
 } from '../types';
-import { TabState, VZAction } from './vzReducer';
+import { VZAction } from './vzReducer';
 
 // This is a custom hook that returns a set of functions
 // that can be used to dispatch actions to the reducer.

--- a/src/client/useURLSync.ts
+++ b/src/client/useURLSync.ts
@@ -1,6 +1,5 @@
 import { useSearchParams } from 'react-router-dom';
-import { FileId, VZCodeContent } from '../types';
-import { TabState } from './vzReducer';
+import { FileId, TabState, VZCodeContent } from '../types';
 import { useEffect, useMemo, useRef } from 'react';
 import {
   TabStateParams,

--- a/src/client/vzReducer/closeTabReducer.test.ts
+++ b/src/client/vzReducer/closeTabReducer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { closeTabsReducer } from './closeTabsReducer';
 import { VZAction, VZState, createInitialState } from '.';
 import { defaultTheme } from '../themes';
@@ -25,8 +25,9 @@ describe('closeTabsReducer', () => {
       action,
     );
 
-    expect(newState.tabList.length).toBe(0);
-    expect(newState.activeFileId).toBeNull();
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(0);
+    expect(newState.pane.activeFileId).toBeNull();
   });
 
   it('Keeps other tabs open', () => {
@@ -36,11 +37,14 @@ describe('closeTabsReducer', () => {
     };
     const stateWithTabs = {
       ...initialState,
-      tabList: [
-        { fileId: 'file1', isTransient: false },
-        { fileId: 'file2', isTransient: false },
-      ],
-      activeFileId: 'file1',
+      pane: {
+        ...initialState.pane,
+        tabList: [
+          { fileId: 'file1', isTransient: false },
+          { fileId: 'file2', isTransient: false },
+        ],
+        activeFileId: 'file1',
+      },
     };
 
     const newState = closeTabsReducer(
@@ -48,24 +52,29 @@ describe('closeTabsReducer', () => {
       action,
     );
 
-    expect(newState.tabList.length).toBe(1);
-    expect(newState.tabList[0].fileId).toBe('file1');
-    expect(newState.activeFileId).toBe('file1');
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(1);
+    expect(newState.pane.tabList[0].fileId).toBe('file1');
+    expect(newState.pane.activeFileId).toBe('file1');
   });
 
-  it('Activates previous tab after closing an active tab', () => {
+  it.only('Activates previous tab after closing an active tab', () => {
     const action: VZAction = {
       type: 'close_tabs',
       fileIdsToClose: ['file2'],
     };
-    const stateWithTabs = {
+    const stateWithTabs: VZState = {
       ...initialState,
-      tabList: [
-        { fileId: 'file1', isTransient: false },
-        { fileId: 'file2', isTransient: false },
-        { fileId: 'file3', isTransient: false },
-      ],
-      activeFileId: 'file2',
+      pane: {
+        ...initialState.pane,
+        type: 'leafPane',
+        tabList: [
+          { fileId: 'file1', isTransient: false },
+          { fileId: 'file2', isTransient: false },
+          { fileId: 'file3', isTransient: false },
+        ],
+        activeFileId: 'file2',
+      },
     };
 
     const newState = closeTabsReducer(
@@ -73,8 +82,9 @@ describe('closeTabsReducer', () => {
       action,
     );
 
-    expect(newState.tabList.length).toBe(2);
-    expect(newState.activeFileId).toBe('file1'); // should switch to the previous tab
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(2);
+    expect(newState.pane.activeFileId).toBe('file1'); // should switch to the previous tab
   });
 
   it('Does not modify the state if closing non-existing tabs', () => {
@@ -84,12 +94,15 @@ describe('closeTabsReducer', () => {
     };
     const stateWithTabs = {
       ...initialState,
-      tabList: [
-        { fileId: 'file1', isTransient: false },
-        { fileId: 'file2', isTransient: false },
-        { fileId: 'file3', isTransient: false },
-      ],
-      activeFileId: 'file2',
+      pane: {
+        ...initialState.pane,
+        tabList: [
+          { fileId: 'file1', isTransient: false },
+          { fileId: 'file2', isTransient: false },
+          { fileId: 'file3', isTransient: false },
+        ],
+        activeFileId: 'file2',
+      },
     };
 
     const newState = closeTabsReducer(
@@ -121,8 +134,9 @@ describe('closeTabsReducer', () => {
       action,
     );
 
-    expect(newState.tabList.length).toBe(2);
-    expect(newState.activeFileId).toBe('file3'); // remains unchanged
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(2);
+    expect(newState.pane.activeFileId).toBe('file3'); // remains unchanged
   });
 
   it('Closes the first tab out of many, when it is active', () => {
@@ -146,8 +160,9 @@ describe('closeTabsReducer', () => {
       action,
     );
 
-    expect(newState.tabList.length).toBe(2);
-    expect(newState.activeFileId).toBe('file2'); // switches to the next available tab
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(2);
+    expect(newState.pane.activeFileId).toBe('file2'); // switches to the next available tab
   });
 
   it('Closes multiple tabs at once', () => {
@@ -171,7 +186,8 @@ describe('closeTabsReducer', () => {
       action,
     );
 
-    expect(newState.tabList.length).toBe(1);
-    expect(newState.activeFileId).toBe('file3'); // switches to the next available tab
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(1);
+    expect(newState.pane.activeFileId).toBe('file3'); // switches to the next available tab
   });
 });

--- a/src/client/vzReducer/createInitialState.ts
+++ b/src/client/vzReducer/createInitialState.ts
@@ -9,8 +9,13 @@ export const createInitialState = ({
   defaultTheme: ThemeLabel;
   initialUsername?: Username;
 }): VZState => ({
-  tabList: [],
-  activeFileId: null,
+  pane: {
+    id: 'root',
+    type: 'leafPane',
+    tabList: [],
+    activeFileId: null,
+  },
+  activePaneId: 'root',
   theme: defaultTheme,
   search: { pattern: '', results: {} },
   isSearchOpen: false,

--- a/src/client/vzReducer/findPane.ts
+++ b/src/client/vzReducer/findPane.ts
@@ -1,0 +1,19 @@
+import { Pane, PaneId } from '../../types';
+
+// Recursively finds a pane by id, given a root pane node.
+export const findPane = (
+  pane: Pane,
+  paneId: PaneId,
+): Pane => {
+  if (pane.id === paneId) {
+    return pane;
+  }
+  if (pane.type === 'splitPane') {
+    for (const child of pane.children) {
+      const foundPane = findPane(child, paneId);
+      if (foundPane) {
+        return foundPane;
+      }
+    }
+  }
+};

--- a/src/client/vzReducer/index.ts
+++ b/src/client/vzReducer/index.ts
@@ -1,5 +1,7 @@
 import {
   FileId,
+  Pane,
+  PaneId,
   SearchFileVisibility,
   SearchResults,
   ShareDBDoc,
@@ -28,48 +30,13 @@ import {
 import { toggleAutoFollowReducer } from './toggleAutoFollowReducer';
 export { createInitialState } from './createInitialState';
 
-// Default case with a single panel looks like this:
-// {
-//   tabList: [
-//     { fileId: '1' },
-//     { fileId: '2' },
-//     { fileId: '3' },
-//   ],
-//   orientation: 'vertical',
-//   children: [],
-// }
-
-// The leaf node of the tree data structure
-type LeafPane = {
-  type: 'leafPane';
-  // The list of tabs
-  // Mutually exclusive with `children`.
-  tabList: Array<TabState>;
-};
-
-// Internal node of the tree data structure
-type SplitPane = {
-  type: 'splitPane';
-  // Which orientation is it? Vertical split or horizontal split?
-  // Applies only to `children`
-  orientation: 'vertical' | 'horizontal';
-
-  // The children panels
-  // Mutually exclusive with `tabList`.
-  children: Array<Pane>;
-};
-
-// The node data structure of the split pane tree
-type Pane = LeafPane | SplitPane;
-
 // The shape of the state managed by the reducer.
 export type VZState = {
   // The state of the split pane (tree data structure).
   pane: Pane;
 
-  // The ID of the file that is currently active.
-  // Invariant: `activeFileId` is always in `tabList`.
-  activeFileId: FileId | null;
+  // The id of the currently active pane.
+  activePaneId: PaneId;
 
   // The theme that is currently active.
   theme: ThemeLabel;
@@ -120,7 +87,11 @@ export type VZAction =
 
   // `close_tabs`
   //  * Closes a set of tabs.
-  | { type: 'close_tabs'; fileIdsToClose: Array<FileId> }
+  | {
+      type: 'close_tabs';
+      fileIdsToClose: Array<FileId>;
+      // The pane id to close tabs from.
+    }
 
   // `set_theme`
   //  * Sets the theme.
@@ -166,25 +137,6 @@ export type VZAction =
   // `toggle_auto_follow
   //  * Toggles the auto-follow feature.
   | { type: 'toggle_auto_follow' };
-
-// Representation of an open tab.
-export type TabState = {
-  // `fileId`
-  // The ID of the file that the tab represents.
-  fileId: FileId;
-
-  // `isTransient`
-  // Represents whether the tab is temporary or persistent.
-  //  * `true` if the tab is temporary, meaning its text
-  //    appears as italic, and it will be automatically
-  //    closed when the user switches to another file.
-  //    If `true` and the tab is opened, the editor will not focus.
-  //  * `false` or `undefined` if the tab is persistent, meaning its text
-  //    appears as normal, and it will not be automatically
-  //    closed when the user switches to another file.
-  //    If `false` and the tab is opened, the editor will focus.
-  isTransient?: boolean;
-};
 
 const reducers = [
   setActiveFileIdReducer,

--- a/src/client/vzReducer/index.ts
+++ b/src/client/vzReducer/index.ts
@@ -32,8 +32,8 @@ export { createInitialState } from './createInitialState';
 
 // The shape of the state managed by the reducer.
 export type VZState = {
-  // The list of open tabs.
-  tabList: Array<TabState>;
+  // The state of the split pane (tree data structure).
+  pane: Pane;
 
   // The id of the currently active pane.
   activePaneId: PaneId;

--- a/src/client/vzReducer/openTabReducer.test.ts
+++ b/src/client/vzReducer/openTabReducer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { openTabReducer } from './openTabReducer';
 import { VZAction, VZState, createInitialState } from '.';
 import { defaultTheme } from '../themes';
@@ -16,16 +16,22 @@ describe('openTabReducer', () => {
     };
     const newState = openTabReducer(initialState, action);
 
-    expect(newState.tabList.length).toBe(1);
-    expect(newState.tabList[0].fileId).toBe('file1');
-    expect(newState.tabList[0].isTransient).toBe(false);
-    expect(newState.activeFileId).toBe('file1');
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(1);
+    expect(newState.pane.tabList[0].fileId).toBe('file1');
+    expect(newState.pane.tabList[0].isTransient).toBe(
+      false,
+    );
+    expect(newState.pane.activeFileId).toBe('file1');
   });
 
   it('Replaces a transient tab', () => {
     const stateWithTransientTab = {
       ...initialState,
-      tabList: [{ fileId: 'file2', isTransient: true }],
+      pane: {
+        ...initialState.pane,
+        tabList: [{ fileId: 'file2', isTransient: true }],
+      },
     };
     const action: VZAction = {
       type: 'open_tab',
@@ -37,16 +43,20 @@ describe('openTabReducer', () => {
       action,
     );
 
-    expect(newState.tabList.length).toBe(1);
-    expect(newState.tabList[0].fileId).toBe('file1');
-    expect(newState.tabList[0].isTransient).toBe(true);
-    expect(newState.activeFileId).toBe('file1');
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(1);
+    expect(newState.pane.tabList[0].fileId).toBe('file1');
+    expect(newState.pane.tabList[0].isTransient).toBe(true);
+    expect(newState.pane.activeFileId).toBe('file1');
   });
 
   it('Does not modify a non-transient tab', () => {
     const stateWithNonTransientTab = {
       ...initialState,
-      tabList: [{ fileId: 'file1', isTransient: false }],
+      pane: {
+        ...initialState.pane,
+        tabList: [{ fileId: 'file1', isTransient: false }],
+      },
     };
     const action: VZAction = {
       type: 'open_tab',
@@ -58,19 +68,25 @@ describe('openTabReducer', () => {
       action,
     );
 
-    expect(newState.tabList.length).toBe(1);
-    expect(newState.tabList[0].fileId).toBe('file1');
-    expect(newState.tabList[0].isTransient).toBe(false); // should remain non-transient
-    expect(newState.activeFileId).toBe('file1');
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(1);
+    expect(newState.pane.tabList[0].fileId).toBe('file1');
+    expect(newState.pane.tabList[0].isTransient).toBe(
+      false,
+    ); // should remain non-transient
+    expect(newState.pane.activeFileId).toBe('file1');
   });
 
   it('Activates an already open tab', () => {
     const stateWithMultipleTabs = {
       ...initialState,
-      tabList: [
-        { fileId: 'file1', isTransient: false },
-        { fileId: 'file2', isTransient: false },
-      ],
+      pane: {
+        ...initialState.pane,
+        tabList: [
+          { fileId: 'file1', isTransient: false },
+          { fileId: 'file2', isTransient: false },
+        ],
+      },
     };
     const action: VZAction = {
       type: 'open_tab',
@@ -82,8 +98,9 @@ describe('openTabReducer', () => {
       action,
     );
 
-    expect(newState.tabList.length).toBe(2);
-    expect(newState.activeFileId).toBe('file1');
+    assert(newState.pane.type === 'leafPane');
+    expect(newState.pane.tabList.length).toBe(2);
+    expect(newState.pane.activeFileId).toBe('file1');
   });
 
   it('Sets editorWantsFocus to true for non-transient tabs', () => {

--- a/src/client/vzReducer/openTabReducer.ts
+++ b/src/client/vzReducer/openTabReducer.ts
@@ -1,5 +1,5 @@
 import { VZAction, VZState } from '.';
-import { Pane } from '../../types';
+import { Pane, TabState } from '../../types';
 import { findPane } from './findPane';
 import { updatePane } from './updatePane';
 

--- a/src/client/vzReducer/setActiveFileIdReducer.ts
+++ b/src/client/vzReducer/setActiveFileIdReducer.ts
@@ -1,9 +1,28 @@
 import { VZAction, VZState } from '.';
+import { Pane } from '../../types';
+import { findPane } from './findPane';
+import { updatePane } from './updatePane';
 
 export const setActiveFileIdReducer = (
   state: VZState,
   action: VZAction,
-): VZState =>
-  action.type === 'set_active_file_id'
-    ? { ...state, activeFileId: action.activeFileId }
-    : state;
+): VZState => {
+  if (action.type !== 'set_active_file_id') return state;
+
+  const { pane, activePaneId } = state;
+  const activePane: Pane = findPane(pane, activePaneId);
+
+  if (activePane.type !== 'leafPane') {
+    throw new Error(
+      'closeTabsReducer: activePane is not a leafPane',
+    );
+  }
+  return {
+    ...state,
+    pane: updatePane({
+      pane,
+      activePaneId,
+      newActiveFileId: action.activeFileId,
+    }),
+  };
+};

--- a/src/client/vzReducer/setActiveFileLeftRightReducer.ts
+++ b/src/client/vzReducer/setActiveFileLeftRightReducer.ts
@@ -1,4 +1,7 @@
 import { VZAction, VZState } from '.';
+import { Pane } from '../../types';
+import { findPane } from './findPane';
+import { updatePane } from './updatePane';
 
 export const setActiveFileLeftReducer = (
   state: VZState,
@@ -8,18 +11,31 @@ export const setActiveFileLeftReducer = (
     return state;
   }
 
-  let index = state.tabList.findIndex(
-    (tab) => tab.fileId === state.activeFileId,
+  const { pane, activePaneId } = state;
+  const activePane: Pane = findPane(pane, activePaneId);
+
+  if (activePane.type !== 'leafPane') {
+    throw new Error(
+      'closeTabsReducer: activePane is not a leafPane',
+    );
+  }
+
+  let index = activePane.tabList.findIndex(
+    (tab) => tab.fileId === activePane.activeFileId,
   );
 
   index -= 1;
   if (index < 0) {
-    index = state.tabList.length - 1;
+    index = activePane.tabList.length - 1;
   }
 
   return {
     ...state,
-    activeFileId: state.tabList[index].fileId,
+    pane: updatePane({
+      pane,
+      activePaneId,
+      newActiveFileId: activePane.tabList[index].fileId,
+    }),
   };
 };
 
@@ -31,17 +47,30 @@ export const setActiveFileRightReducer = (
     return state;
   }
 
-  let index = state.tabList.findIndex(
-    (tab) => tab.fileId === state.activeFileId,
+  const { pane, activePaneId } = state;
+  const activePane: Pane = findPane(pane, activePaneId);
+
+  if (activePane.type !== 'leafPane') {
+    throw new Error(
+      'closeTabsReducer: activePane is not a leafPane',
+    );
+  }
+
+  let index = activePane.tabList.findIndex(
+    (tab) => tab.fileId === activePane.activeFileId,
   );
 
   index += 1;
-  if (index > state.tabList.length - 1) {
+  if (index > activePane.tabList.length - 1) {
     index = 0;
   }
 
   return {
     ...state,
-    activeFileId: state.tabList[index].fileId,
+    pane: updatePane({
+      pane,
+      activePaneId,
+      newActiveFileId: activePane.tabList[index].fileId,
+    }),
   };
 };

--- a/src/client/vzReducer/updatePane.ts
+++ b/src/client/vzReducer/updatePane.ts
@@ -1,0 +1,41 @@
+import {
+  FileId,
+  Pane,
+  PaneId,
+  TabState,
+} from '../../types';
+
+// Immutable update pattern for updating a pane's tab list.
+export const updatePane = ({
+  pane,
+  activePaneId,
+  newTabList,
+  newActiveFileId,
+}: {
+  pane: Pane;
+  activePaneId: PaneId;
+  newTabList: Array<TabState>;
+  newActiveFileId?: FileId | null;
+}): Pane =>
+  pane.type === 'splitPane'
+    ? {
+        ...pane,
+        children: pane.children.map((child) =>
+          updatePane({
+            pane: child,
+            activePaneId,
+            newTabList,
+            newActiveFileId,
+          }),
+        ),
+      }
+    : pane.id === activePaneId
+      ? {
+          ...pane,
+          tabList: newTabList,
+          activeFileId:
+            newActiveFileId !== undefined
+              ? newActiveFileId
+              : pane.activeFileId,
+        }
+      : pane;

--- a/src/client/vzReducer/updatePane.ts
+++ b/src/client/vzReducer/updatePane.ts
@@ -14,7 +14,7 @@ export const updatePane = ({
 }: {
   pane: Pane;
   activePaneId: PaneId;
-  newTabList: Array<TabState>;
+  newTabList?: Array<TabState>;
   newActiveFileId?: FileId | null;
 }): Pane =>
   pane.type === 'splitPane'
@@ -32,7 +32,10 @@ export const updatePane = ({
     : pane.id === activePaneId
       ? {
           ...pane,
-          tabList: newTabList,
+          tabList:
+            newTabList !== undefined
+              ? newTabList
+              : pane.tabList,
           activeFileId:
             newActiveFileId !== undefined
               ? newActiveFileId

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,67 @@ export interface SearchResults {
   results: SearchResult;
 }
 
+// Representation of an open tab.
+export type TabState = {
+  // `fileId`
+  // The ID of the file that the tab represents.
+  fileId: FileId;
+
+  // `isTransient`
+  // Represents whether the tab is temporary or persistent.
+  //  * `true` if the tab is temporary, meaning its text
+  //    appears as italic, and it will be automatically
+  //    closed when the user switches to another file.
+  //    If `true` and the tab is opened, the editor will not focus.
+  //  * `false` or `undefined` if the tab is persistent, meaning its text
+  //    appears as normal, and it will not be automatically
+  //    closed when the user switches to another file.
+  //    If `false` and the tab is opened, the editor will focus.
+  isTransient?: boolean;
+};
+
+// PaneId
+//   * A unique ID for a pane.
+//   * This is a random string.
+export type PaneId = string;
+
+// The leaf node of the tree data structure
+export type LeafPane = {
+  type: 'leafPane';
+  // The list of tabs
+  // Mutually exclusive with `children`.
+  tabList: Array<TabState>;
+
+  // The ID of the file that is currently active
+  // within this leaf pane.
+  // Invariant: `activeFileId` is always in `tabList`.
+  activeFileId: FileId | null;
+};
+
+// Internal node of the tree data structure
+export type SplitPane = {
+  type: 'splitPane';
+
+  // Which orientation is it? Vertical split or horizontal split?
+  // Applies only to `children`
+  orientation: 'vertical' | 'horizontal';
+
+  // The children panels
+  // Mutually exclusive with `tabList`.
+  children: Array<Pane>;
+};
+
+// The node data structure of the split pane tree
+export type Pane = {
+  // Every pane gets a unique ID,
+  // so we can refer to it in actions.
+  id: PaneId;
+
+  // The type of the pane
+  // Either a leaf pane or a split pane.
+  type: 'leafPane' | 'splitPane';
+} & (LeafPane | SplitPane);
+
 export type JSONOp = any;
 
 // `ShareDBDoc`


### PR DESCRIPTION
This set of changes is a fairly large refactoring to introduce a recursive data structure representing split panes. 

This is the foundation upon which we can build out the split pane functionality described in #705 .

The main change is introduction of these types:

```ts
// PaneId
//   * A unique ID for a pane.
//   * This is a random string.
export type PaneId = string;

// The leaf node of the tree data structure
export type LeafPane = {
  type: 'leafPane';
  // The list of tabs
  // Mutually exclusive with `children`.
  tabList: Array<TabState>;

  // The ID of the file that is currently active
  // within this leaf pane.
  // Invariant: `activeFileId` is always in `tabList`.
  activeFileId: FileId | null;
};

// Internal node of the tree data structure
export type SplitPane = {
  type: 'splitPane';

  // Which orientation is it? Vertical split or horizontal split?
  // Applies only to `children`
  orientation: 'vertical' | 'horizontal';

  // The children panels
  // Mutually exclusive with `tabList`.
  children: Array<Pane>;
};

// The node data structure of the split pane tree
export type Pane = {
  // Every pane gets a unique ID,
  // so we can refer to it in actions.
  id: PaneId;

  // The type of the pane
  // Either a leaf pane or a split pane.
  type: 'leafPane' | 'splitPane';
} & (LeafPane | SplitPane);
```

then updating the rest of the codebase to match.