### PR TITLE
presence color revamp and intial pass at syncing

### DIFF
--- a/src/client/CodeEditor/json1PresenceDisplay.ts
+++ b/src/client/CodeEditor/json1PresenceDisplay.ts
@@ -88,14 +88,11 @@ export const json1PresenceDisplay = ({
               presence,
             );
 
-// Initialize or update presence with user color
-const initializePresence = (id: string, presence: Presence): Presence => {
-  return assignUserColor(presence, id);
-};
+
 
   // If the presence is in the current file, update the presence state with the color.
   if (isPresenceInCurrentFile) {
-    presenceState[id] = initializePresence(id, presence);    
+    presenceState[id] = presence;    
     console.log('Structure of original presence object:', JSON.stringify(presenceState[id], null, 2));
   } else if (presence) {
     // Otherwise, delete the presence state.
@@ -116,7 +113,8 @@ const initializePresence = (id: string, presence: Presence): Presence => {
 
   for (const id of Object.keys(presenceState)) {
     const presence: Presence = presenceState[id];
-    const { start, end, userColor } = presence; // Use the color here
+    const { start, end } = presence; // Use the color here
+    const userColor = assignUserColor(presence.username); 
     const from = +start[start.length - 1];
     const to = +end[end.length - 1];
 
@@ -128,7 +126,7 @@ const initializePresence = (id: string, presence: Presence): Presence => {
         block: false,
         widget: new PresenceWidget(
           '' + Math.random(),
-          userColor, // Fallback color
+          userColor, 
           presence.username,
         ),
                 }),
@@ -145,7 +143,7 @@ const initializePresence = (id: string, presence: Presence): Presence => {
                     class: 'cm-json1-presence',
                     attributes: {
                       style: `
-                      background-color: rgba(${presence.userColor}, 0.75);
+                      background-color: rgba(${assignUserColor(presence.username)}, 0.75);
                       mix-blend-mode: luminosity;
                       `,
                     },

--- a/src/client/CodeEditor/json1PresenceDisplay.ts
+++ b/src/client/CodeEditor/json1PresenceDisplay.ts
@@ -5,7 +5,7 @@ import {
   Decoration,
 } from '@codemirror/view';
 import { Annotation, RangeSet } from '@codemirror/state';
-import ColorHash from 'color-hash';
+import { assignUserColor } from '../presenceColor';
 import {
   FileId,
   Presence,
@@ -88,14 +88,15 @@ export const json1PresenceDisplay = ({
               presence,
             );
 
-            // Generate user color based on the id
-  const userColor = new ColorHash({ lightness: 0.75 }).rgb(id).join(',');
+// Initialize or update presence with user color
+const initializePresence = (id: string, presence: Presence): Presence => {
+  return assignUserColor(presence, id);
+};
 
   // If the presence is in the current file, update the presence state with the color.
   if (isPresenceInCurrentFile) {
-    presenceState[id] = presence;
-    presenceState[id].userColor = userColor;  // Add color to the presence
-    console.log('Emitting presence with userColor:', presence.userColor);
+    presenceState[id] = initializePresence(id, presence);    
+    console.log('Structure of original presence object:', JSON.stringify(presenceState[id], null, 2));
   } else if (presence) {
     // Otherwise, delete the presence state.
     delete presenceState[id];
@@ -127,7 +128,7 @@ export const json1PresenceDisplay = ({
         block: false,
         widget: new PresenceWidget(
           '' + Math.random(),
-          userColor || 'rgb(0, 0, 0)', // Fallback color
+          userColor, // Fallback color
           presence.username,
         ),
                 }),

--- a/src/client/VZSidebar/FileListing.tsx
+++ b/src/client/VZSidebar/FileListing.tsx
@@ -92,6 +92,7 @@ export const FileListing = ({
             <div
               key={index}
               className="presence-indicator"
+              //style={{ backgroundColor: 'blue' }} // Hardcoded color for testing
               style={{ backgroundColor: indicator.userColor }}
             >
               {indicator.username[0]}

--- a/src/client/VZSidebar/FileListing.tsx
+++ b/src/client/VZSidebar/FileListing.tsx
@@ -55,8 +55,7 @@ export const FileListing = ({
   isActive: boolean;
   presence: PresenceIndicator[];
 }) => {
-  const { renameFile, deleteFile } =
-    useContext(VZCodeContext);
+  const { renameFile, deleteFile } = useContext(VZCodeContext);
 
   const handleClick = useCallback(() => {
     handleFileClick(fileId);
@@ -87,26 +86,21 @@ export const FileListing = ({
       handleRenameClick={handleRenameClick}
       isActive={isActive}
     >
-      <div className="name">
-        {/* Render presence indicators to the left of the file name */}
-        {presence.length > 0 && (
-          <div className="presence-indicators">
-            {presence.map((indicator, index) => (
-              <div
-                key={index}
-                className="presence-indicator"
-              >
-                {indicator.username[0]}{' '}
-                {/* Display the first letter of the username */}
-              </div>
-            ))}
-          </div>
-        )}
-        <i className="file-icon">
-          {getExtensionIcon(name)}
-        </i>
-        {name}
-      </div>
+      {presence.length > 0 && (
+        <div className="presence-indicators">
+          {presence.map((indicator, index) => (
+            <div
+              key={index}
+              className="presence-indicator"
+              style={{ backgroundColor: indicator.userColor }}
+            >
+              {indicator.username[0]}
+            </div>
+          ))}
+        </div>
+      )}
+      <i className="file-icon">{getExtensionIcon(name)}</i>
+      {name}
     </Item>
   );
 };

--- a/src/client/VZSidebar/FileListing.tsx
+++ b/src/client/VZSidebar/FileListing.tsx
@@ -13,6 +13,7 @@ import {
   CssSVG,
 } from '../Icons';
 import { VZCodeContext } from '../VZCodeContext';
+import { assignUserColor } from '../presenceColor';
 
 export function getExtensionIcon(fileName: string) {
   const extension = fileName.split('.');
@@ -92,8 +93,8 @@ export const FileListing = ({
             <div
               key={index}
               className="presence-indicator"
-              //style={{ backgroundColor: 'blue' }} // Hardcoded color for testing
-              style={{ backgroundColor: indicator.userColor }}
+              style={{ backgroundColor: 'blue' }} // Hardcoded color for testing
+              //style={{ backgroundColor: assignUserColor(indicator.username) }}
             >
               {indicator.username[0]}
             </div>
@@ -105,3 +106,5 @@ export const FileListing = ({
     </Item>
   );
 };
+
+console.log(assignUserColor('bill'));

--- a/src/client/VZSidebar/index.tsx
+++ b/src/client/VZSidebar/index.tsx
@@ -187,15 +187,12 @@ export const VZSidebar = ({
         update: Presence,
       ) =>
          {
-        const updatedPresence = assignUserColor(update, presenceId);
+        const updatedPresenceColor = assignUserColor(update.username);
         const presenceIndicator: PresenceIndicator = {
-          username: updatedPresence.username,
-          fileId: updatedPresence.start[1] as FileId,
-          userColor: updatedPresence.userColor,
+          username: update.username,
+          fileId: update.start[1] as FileId,
 
         };
-        console.log('Structure of updated object:', JSON.stringify(presenceIndicator, null, 2));
-
         updatePresenceIndicator(presenceIndicator);
       };
 

--- a/src/client/VZSidebar/index.tsx
+++ b/src/client/VZSidebar/index.tsx
@@ -32,6 +32,8 @@ import { VZCodeContext } from '../VZCodeContext';
 import { Listing } from './Listing';
 import { useDragAndDrop } from './useDragAndDrop';
 import './styles.scss';
+import { assignUserColor } from '../presenceColor';
+
 
 // TODO turn this UI back on when we are actually detecting
 // the connection status.
@@ -183,19 +185,16 @@ export const VZSidebar = ({
       const handleReceive = (
         presenceId: PresenceId,
         update: Presence,
-      ) => {
-        console.log('Received update object:', update);
+      ) =>
+         {
+        const updatedPresence = assignUserColor(update, presenceId);
         const presenceIndicator: PresenceIndicator = {
-          username: update.username,
-          fileId: update.start[1] as FileId,
-          userColor: update.userColor,
-          
+          username: updatedPresence.username,
+          fileId: updatedPresence.start[1] as FileId,
+          userColor: updatedPresence.userColor,
+
         };
-        console.log('Got presence!', update);
-        const userColor = update.userColor;
-        console.log ('got user color', userColor);
-        console.log (update.username, presenceIndicator.username, update.userColor, presenceIndicator.userColor);
-        console.log({presenceId, update})
+        console.log('Structure of updated object:', JSON.stringify(presenceIndicator, null, 2));
 
         updatePresenceIndicator(presenceIndicator);
       };

--- a/src/client/VZSidebar/index.tsx
+++ b/src/client/VZSidebar/index.tsx
@@ -184,16 +184,18 @@ export const VZSidebar = ({
         presenceId: PresenceId,
         update: Presence,
       ) => {
+        console.log('Received update object:', update);
         const presenceIndicator: PresenceIndicator = {
           username: update.username,
           fileId: update.start[1] as FileId,
+          userColor: update.userColor,
+          
         };
-
-        console.log('Got presence!');
-        // console.log({presenceId,update})
-        console.log(
-          JSON.stringify(presenceIndicator, null, 2),
-        );
+        console.log('Got presence!', update);
+        const userColor = update.userColor;
+        console.log ('got user color', userColor);
+        console.log (update.username, presenceIndicator.username, update.userColor, presenceIndicator.userColor);
+        console.log({presenceId, update})
 
         updatePresenceIndicator(presenceIndicator);
       };
@@ -205,7 +207,7 @@ export const VZSidebar = ({
     }
   }, [docPresence]);
 
-  console.log(sidebarPresenceIndicators);
+  //console.log(sidebarPresenceIndicators);
 
   return (
     <div

--- a/src/client/VZSidebar/styles.scss
+++ b/src/client/VZSidebar/styles.scss
@@ -260,13 +260,13 @@
     overflow: hidden;
     gap: 6px;
   }
-
+  
   .presence-indicators {
     display: flex;
     gap: 4px;
-    margin-right: 6px; /* Space between the indicators and the file name */
+    margin-right: 6px; 
   }
-
+  
   .presence-indicator {
     width: 16px;
     height: 16px;
@@ -275,7 +275,6 @@
     align-items: center;
     justify-content: center;
     font-size: 10px;
-    background-color: #ff5733;
     color: #ffffff;
   }
 }

--- a/src/client/presenceColor.ts
+++ b/src/client/presenceColor.ts
@@ -1,0 +1,7 @@
+import ColorHash from 'color-hash';
+import { Presence } from '../types';
+
+export const assignUserColor = (presence: Presence, id: string): Presence => {
+  const userColor = new ColorHash({ lightness: 0.75 }).rgb(id).join(',');
+  return { ...presence, userColor };
+};

--- a/src/client/presenceColor.ts
+++ b/src/client/presenceColor.ts
@@ -1,7 +1,7 @@
 import ColorHash from 'color-hash';
 import { Presence } from '../types';
 
-export const assignUserColor = (presence: Presence, id: string): Presence => {
-  const userColor = new ColorHash({ lightness: 0.75 }).rgb(id).join(',');
-  return { ...presence, userColor };
+export const assignUserColor = (name: string): string => {
+  const userColor = new ColorHash({ lightness: 0.75 }).rgb(name).join(',');
+  return userColor;
 };

--- a/src/client/vzReducer/updatePresenceIndicatorReducer.ts
+++ b/src/client/vzReducer/updatePresenceIndicatorReducer.ts
@@ -5,19 +5,18 @@ export const updatePresenceIndicatorReducer = (
   action: VZAction,
 ): VZState => {
   if (action.type === 'update_presence_indicator') {
-    // True if there's already an entry for this user.
-    const needsUpdate =
-      state.sidebarPresenceIndicators.find(
-        (d) =>
-          d.username === action.presenceIndicator.username,
-      );
+    const { username, userColor } = action.presenceIndicator;
+
+    const needsUpdate = state.sidebarPresenceIndicators.find(
+      (d) => d.username === username,
+    );
 
     return {
       ...state,
       sidebarPresenceIndicators: needsUpdate
         ? state.sidebarPresenceIndicators.map((d) =>
-            d.username === action.presenceIndicator.username
-              ? action.presenceIndicator
+            d.username === username
+              ? { ...d, userColor: userColor || '#FFFFFF' } // Ensure userColor is updated
               : d,
           )
         : [

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,7 +212,6 @@ export type Presence = {
   start: Array<string | number>;
   end: Array<string | number>;
   username: Username;
-  userColor: string; // Optional color field
 };
 
 // An item in the list of sidebar presence indicators.
@@ -222,7 +221,6 @@ export type Presence = {
 export type PresenceIndicator = {
   username: Username;
   fileId: FileId;
-  userColor: string; // Optional color field
 };
 
 // An id used for presence.

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,10 +207,12 @@ export type VZCodeContent = {
 //   ],
 //   "username": "Tim"
 // }
+
 export type Presence = {
   start: Array<string | number>;
   end: Array<string | number>;
   username: Username;
+  userColor: string; // Optional color field
 };
 
 // An item in the list of sidebar presence indicators.
@@ -220,6 +222,7 @@ export type Presence = {
 export type PresenceIndicator = {
   username: Username;
   fileId: FileId;
+  userColor: string; // Optional color field
 };
 
 // An id used for presence.


### PR DESCRIPTION
This is an intail pass at color matching. I tried revamping presence to store a color componant but im running into an issue that I dont know how to solve.

Console log:
<img width="293" alt="image" src="https://github.com/user-attachments/assets/dfb828f4-7ab8-47c2-a83a-83db561bdf6c">

in index.tsx, you will see the console logs before and after I try to access and assign the userColor via update.userColor (the same way the username is assigned).

However, for some reason, the colors end up as null, even though the update object is clearly logged to have a populated color component. 

I tried to fix this but I have no idea how, as after those are recorded as null, the next console log shows that update still has its userColor component. 
