### PR TITLE
Start on fixing editor cache key mismatches

### DIFF
--- a/src/client/AIAssist/AIAssistWidget/index.tsx
+++ b/src/client/AIAssist/AIAssistWidget/index.tsx
@@ -27,6 +27,7 @@ export const AIAssistWidget = ({
   const {
     shareDBDoc,
     activeFileId,
+    activePaneId,
     tabList,
     editorCache,
     runPrettierRef,

--- a/src/client/AIAssist/AIAssistWidget/index.tsx
+++ b/src/client/AIAssist/AIAssistWidget/index.tsx
@@ -8,6 +8,7 @@ import {
 import { SparklesSVG } from '../../Icons';
 import { startAIAssist } from '../startAIAssist';
 import { Spinner } from '../Spinner';
+import { editorCacheKey } from '../../useEditorCache';
 import './style.scss';
 
 const enableStopGeneration = false;
@@ -23,8 +24,14 @@ export const AIAssistWidget = ({
   aiAssistTooltipText?: string;
   aiAssistClickOverride?: () => void;
 }) => {
-  const { shareDBDoc, activeFileId, tabList, editorCache } =
-    useContext(VZCodeContext);
+  const {
+    shareDBDoc,
+    activeFileId,
+    tabList,
+    editorCache,
+    runPrettierRef,
+    runCodeRef,
+  } = useContext(VZCodeContext);
 
   // The stream ID of the most recent request.
   //  * If `null`, no request has been made yet.
@@ -32,9 +39,6 @@ export const AIAssistWidget = ({
   //    server is processing it.
   const [aiStreamId, setAiStreamId] =
     useState<RequestId | null>(null);
-
-  const { runPrettierRef, runCodeRef } =
-    useContext(VZCodeContext);
 
   const handleClick = useCallback(async () => {
     const isCurrentlyGenerationg = aiStreamId !== null;
@@ -46,7 +50,9 @@ export const AIAssistWidget = ({
 
       // Wait for generation to finish.
       await startAIAssist({
-        view: editorCache.get(activeFileId).editor,
+        view: editorCache.get(
+          editorCacheKey(activeFileId, activePaneId),
+        ).editor,
         shareDBDoc,
         fileId: activeFileId,
         tabList,
@@ -89,7 +95,7 @@ export const AIAssistWidget = ({
           : currentAIStreamId,
       );
     }
-  }, [activeFileId, aiStreamId]);
+  }, [activeFileId, activePaneId, aiStreamId]);
 
   const showWidget = enableStopGeneration
     ? true

--- a/src/client/CodeEditor/getOrCreateEditor.ts
+++ b/src/client/CodeEditor/getOrCreateEditor.ts
@@ -33,6 +33,7 @@ import {
 } from './InteractiveWidgets';
 import {
   EditorCache,
+  editorCacheKey,
   EditorCacheValue,
 } from '../useEditorCache';
 import { ThemeLabel, themeOptionsByLabel } from '../themes';
@@ -158,7 +159,7 @@ export const getOrCreateEditor = ({
 }): EditorCacheValue => {
   // Cache hit
 
-  const cacheKey = fileId + '|' + paneId;
+  const cacheKey = editorCacheKey(fileId, paneId);
 
   if (editorCache.has(cacheKey)) {
     return editorCache.get(cacheKey);

--- a/src/client/VZCodeContext.tsx
+++ b/src/client/VZCodeContext.tsx
@@ -16,6 +16,8 @@ import {
   SearchFileVisibility,
   TabState,
   PresenceIndicator,
+  Pane,
+  PaneId,
 } from '../types';
 import { usePrettier } from './usePrettier';
 import { useTypeScript } from './useTypeScript';
@@ -74,6 +76,8 @@ export type VZCodeContextValue = {
   setActiveFileId: (fileId: string | null) => void;
   setActiveFileLeft: () => void;
   setActiveFileRight: () => void;
+
+  activePaneId: PaneId;
 
   tabList: Array<TabState>;
   openTab: (tabState: TabState) => void;
@@ -235,6 +239,7 @@ export const VZCodeProvider = ({
   // console.log('state: ', state);
   const {
     pane,
+    activePaneId,
     theme,
     search,
     isSearchOpen,
@@ -394,6 +399,8 @@ export const VZCodeProvider = ({
     setActiveFileId,
     setActiveFileLeft,
     setActiveFileRight,
+
+    activePaneId,
 
     tabList,
     openTab,

--- a/src/client/useEditorCache.ts
+++ b/src/client/useEditorCache.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { FileId } from '../types';
+import { FileId, PaneId } from '../types';
 import { EditorView } from 'codemirror';
 
 export type EditorCacheValue = {
@@ -8,7 +8,17 @@ export type EditorCacheValue = {
   scrollPosition?: number;
 };
 
-export type EditorCache = Map<FileId, EditorCacheValue>;
+export type EditorCacheKey = string;
+
+export const editorCacheKey = (
+  fileId: FileId,
+  paneId: PaneId,
+): EditorCacheKey => fileId + '|' + paneId;
+
+export type EditorCache = Map<
+  EditorCacheKey,
+  EditorCacheValue
+>;
 
 export const useEditorCache = () => {
   // Singleton cache of CodeMirror instances


### PR DESCRIPTION
It turns out the split pane changes broke some things because other parts of the code try to look up values from the editor cache using the old key scheme.