### PR TITLE
Added z-index in presence-indicator

### DIFF
--- a/src/client/VZSidebar/styles.scss
+++ b/src/client/VZSidebar/styles.scss
@@ -291,5 +291,7 @@
     justify-content: center;
     font-size: 8px;
     color: #000000;
+    z-index: 1;
   }
 }
+


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/93fb9886-4ef8-44e8-99b2-61d27694e71b)

Issue of user presence icon being behind the file icon is fixed. Brought the presence icon forwards by setting z-index to 1.