### PR TITLE
WIP adopt new viz types package

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,36 +1,13 @@
-// FileId
-//   * A unique ID for a file.
-//   * This is a random string.
-export type FileId = string;
+import { VizFile, VizFileId, VizFiles } from './viz-types';
+
+export type FileId = VizFileId;
+export type File = VizFile;
+export type Files = VizFiles;
 
 // ItemId
 //   * A unique ID for an item in the sidebar.
 //   * This could be either a file ID or a directory path.
 export type ItemId = FileId | FileTreePath;
-
-// Files
-//  * A collection of files.
-//  * Keys are _not_ file names or array indices,
-//    because based on past experience, that
-//    leads to very difficult frontend logic around
-//    OT in the case that a file is renamed or deleted.
-//  * When the file name changes, or files are added/deleted,
-//    this ID stays the same, simplifying things re:OT.
-export interface Files {
-  [fileId: FileId]: File;
-}
-
-// File
-//  * A file with `name` and `text`.
-export interface File {
-  // The file name.
-  // e.g. "index.html".
-  name: string;
-
-  // The text content of the file.
-  // e.g. "<body>Hello</body>"
-  text: string;
-}
 
 // FileTreePath
 //  * The path to the directory, e.g. "src/components", OR

--- a/src/viz-types.ts
+++ b/src/viz-types.ts
@@ -1,0 +1,28 @@
+// VizFileId
+//   * A unique ID for a file.
+//   * This is a random string.
+export type VizFileId = string;
+
+// VizFiles
+//  * A collection of files.
+//  * Keys are _not_ file names or array indices,
+//    because based on past experience, that
+//    leads to very difficult frontend logic around
+//    OT in the case that a file is renamed or deleted.
+//  * When the file name changes, or files are added/deleted,
+//    this ID stays the same, simplifying things re:OT.
+export type VizFiles = {
+  [fileId: VizFileId]: VizFile;
+};
+
+// VizFile
+//  * A file with `name` and `text`.
+export type VizFile = {
+  // The file name.
+  // e.g. "index.html".
+  name: string;
+
+  // The text content of the file.
+  // e.g. "<body>Hello</body>"
+  text: string;
+};


### PR DESCRIPTION
Work in progress...

The idea is to adopt this package https://www.npmjs.com/package/@vizhub/viz-types

as part of a giant refactoring of the VizHub codebase to split it up into smaller packages.

Currently the dependencies are all tangled up, where the vizhub runtime has a dependency on VZCode, just to access these types. I figured it would be best to move these types to a separate package, and continue the refactor from there.