### PR TITLE
Bump throttle interval due to MongoDB issues

### DIFF
--- a/src/server/aiChatHandler/llmStreaming.ts
+++ b/src/server/aiChatHandler/llmStreaming.ts
@@ -32,7 +32,7 @@ const slowMode = false;
 // MongoDB VizHub server got in fact overloaded with
 // too many updates from the AI streaming response, with
 // warning: "Replication Oplog Window has gone below 1 hour"
-const THROTTLE_INTERVAL_MS = 100;
+const THROTTLE_INTERVAL_MS = 500;
 
 // Feature flag to enable/disable streaming editing.
 // * If `true`, the AI streaming response will be used to


### PR DESCRIPTION
Again getting `"Replication Oplog Window has gone below 1 hour"` in production, maybe too many AI changes happening at once.